### PR TITLE
DIT SSO Implementation

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # minimum env vars required
 SUPPORT_EMAIL=support@example.com
 
-# allow read-only access from local development
-READONLY_IP_WHITELIST=127.0.0.1
+# allow read-only access from a specific IP address
+READONLY_IP_WHITELIST=

--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,9 @@
 # NOTE: .env file will override vars defined here.
 #
 GECKOBOARD_API_KEY=moj_geckoboard_api_key
-GPLUS_CLIENT_ID=localdev_gplus_client_id
-GPLUS_CLIENT_SECRET=localdev_gplus_client_secret
+DITSSO_INTERNAL_PROVIDER=
+DITSSO_INTERNAL_CLIENT_ID=localdev_ditsso_client_id
+DITSSO_INTERNAL_CLIENT_SECRET=localdev_ditsso_client_secret
 SSL_ON=false
 GA_TRACKING_ID=UA-XXXXX-X
 MAX_TOKENS_PER_HOUR=8

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'keen'
 gem 'mail', '~> 2.6.6.rc1'
 gem 'mini_magick'
 gem 'netaddr'
+gem 'omniauth-oauth2'
 gem 'paper_trail', '~> 4.0.2'
 gem 'pg'
 gem 'premailer-rails', '~> 1.9'
@@ -47,8 +48,6 @@ gem 'will_paginate-bootstrap', '~> 1.0', '>= 1.0.1'
 gem 'carrierwave',
   git: 'https://github.com/carrierwaveuploader/carrierwave.git',
   tag: 'cc39842e44edcb6187b2d379a606ec48a6b5e4a8'
-gem 'omniauth-gplus',
-  git: 'https://github.com/ministryofjustice/omniauth-gplus.git'
 
 group :assets do
   gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,13 +24,6 @@ GIT
     sentry-raven (0.14.0)
       faraday (>= 0.7.6)
 
-GIT
-  remote: https://github.com/ministryofjustice/omniauth-gplus.git
-  revision: c9b013d10c6af55d9eb92d41191e7e0d036ef7c9
-  specs:
-    omniauth-gplus (2.0.1)
-      omniauth-oauth2 (~> 1.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -666,7 +659,7 @@ DEPENDENCIES
   mini_magick
   minitest
   netaddr
-  omniauth-gplus!
+  omniauth-oauth2
   paper_trail (~> 4.0.2)
   pg
   poltergeist

--- a/README.md
+++ b/README.md
@@ -108,48 +108,25 @@ In rails console:
 PermittedDomain.create(domain: 'some.domain.gov.uk')
 ```
 
-## Authentication
+## DIT SSO Authentication
 
-Authentication for Log in to People Finder in the various environments (dev/staging/prod) is handled by the setting of `GPLUS_CLIENT_ID` and `GP_CLIENT_SECRET` environment variables in the [private People Finder Deployment repo](https://github.com/uktrade/pf-deploy/)
-
-You can configure your local machine for authentication by obtaining an OAuth Client ID and Secret from google+ and setting them in a `.env.local` file (.gitignore'd).
-
-To create your own ID and SECRET:
-
-  * visit the [Google Developers Console](https://console.developers.google.com/).
-  * Create a project, optionally naming it `PeopleFinder-local`, and wait for the process to complete.
-
-  * Select **Google+ API** from the central panel "Overview", then hit the Enable button. Wait for process to complete then follow link to **Go to Credentials** or choose **Credentials** from left sidebar, then follow the steps required to create an **OAuth 2.0 client ID** for a **Web application**.
-
-  * On **OAuth consent page** you can optonally set the **Product name** to `PeopleFinder-local`
-  * On the credentials page:
-    * set Application type to Web application
-    * set Name to `PeopleFinder-local`
-    * set **Authorized JavaScript origins** to the root (e.g. `http://localhost:3000`)
-    * set **Authorized redirect URIs** to the OAuth redirect path, currently `http://localhost:3000/auth/gplus/callback`, but check routes.rb
-
-Hit create/continue until process is complete and you will receive a client ID and client SECRET.
-
-For local development purposes the ID and SECRET can be stored in your bash profile or you can create an `.env.local` file based on `.env.example` and set them, as below.
-
-```
-GPLUS_CLIENT_ID=your_gplus_client_id
-GPLUS_CLIENT_SECRET=your_gplus_client_secret
-```
-
-The permitted domains are configured in `config/application.rb`.
+Authentication to Log in to People Finder in the various environments (dev/staging/prod) is by setting the following environment variables:
+`DITSSO_INTERNAL_PROVIDER`
+`DITSSO_INTERNAL_CLIENT_ID`
+`DITSSO_INTERNAL_CLIENT_SECRET`
 
 ## Token-based authentication
 
-An alternative 'token-based' authentication method is also supported. The
+**NOTE: This has been replaced by DIT SSO Internal**
+~~An alternative 'token-based' authentication method is also supported. The
 token authentication method relies upon the users access to their email
-account to authenticate them.
+account to authenticate them.~~
 
-Each time the user wishes to start a session, they need to generate an
+~~Each time the user wishes to start a session, they need to generate an
 authentication token. This can be done by entering their email address
 (from a permitted domain) on the login screen. They will be sent an email
 message containing a link with a unique random token. Clicking on the link
-will allow them to login.
+will allow them to login.~~
 
 
 ## E-mails

--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ Authentication to Log in to People Finder in the various environments (dev/stagi
 
 ## Token-based authentication
 
-**NOTE: This has been replaced by DIT SSO Internal**
+**NOTE: This has been disabled for DIT SSO Internal**
+
+To enable Token-based authentication, set the environment variable `ENABLE_TOKEN_AUTH` to any value.
+
 ~~An alternative 'token-based' authentication method is also supported. The
 token authentication method relies upon the users access to their email
 account to authenticate them.~~

--- a/app/controllers/problem_reports_controller.rb
+++ b/app/controllers/problem_reports_controller.rb
@@ -11,14 +11,14 @@ class ProblemReportsController < ApplicationController
   private
 
   # This method returns the path that the user came here from, unless it was from a path
-  # which doesn't exist within the application, or from the /auth/gplus path (which would
+  # which doesn't exist within the application, or from the /auth/ditsso_internal path (which would
   # cause a CSRF error). In either of these cases we redirect to the login page.
   #
   def valid_return_path_or_login
     return_path = request.env['HTTP_REFERER']
     begin
       path_hash = Rails.application.routes.recognize_path(return_path)
-      return_path = new_sessions_path if path_hash[:provider] == 'gplus'
+      return_path = new_sessions_path if path_hash[:provider] == 'ditsso_internal'
     rescue ActionController::RoutingError
       return_path = new_sessions_path
     end

--- a/app/views/sessions/_login_page.html.haml
+++ b/app/views/sessions/_login_page.html.haml
@@ -36,5 +36,5 @@
     %p
       = t('.body_google')
     %p
-      = link_to t('.log_in_google'), "/auth/gplus", class: 'button login-button'
+      = link_to t('.log_in_google'), "/auth/ditsso_internal", class: 'button login-button'
 

--- a/app/views/sessions/_login_page.html.haml
+++ b/app/views/sessions/_login_page.html.haml
@@ -2,23 +2,24 @@
 - @page_title = 'Log in'
 - content_for :body_classes, 'login-page '
 
-.grid-row.mod-heading
-  .column-full
-    %h1.heading-xlarge.mod-heading-border
-      - if @unauthorised_login
-        = t('.heading_unauthorised')
-      - else
-        = t('.heading')
-
-    %p.lede
-      - if @unauthorised_login
-        - t('.intro_unauthorised', ttl: distance_of_time_in_words(Token.ttl)).each_line do |line|
-          = line
-      -else
-        - t('.intro', ttl: distance_of_time_in_words(Token.ttl)).each_line do |line|
-          = line
-
 - if feature_enabled?('token_auth')
+  .grid-row.mod-heading
+    .column-full
+      %h1.heading-xlarge.mod-heading-border
+        - if @unauthorised_login
+          = t('.heading_unauthorised')
+        - else
+          = t('.heading')
+
+      %p.lede
+        - if @unauthorised_login
+          - t('.intro_unauthorised', ttl: distance_of_time_in_words(Token.ttl)).each_line do |line|
+            = line
+        -else
+          - t('.intro', ttl: distance_of_time_in_words(Token.ttl)).each_line do |line|
+            = line
+
+
   %h2.heading-medium
     = t('.heading_other')
 
@@ -31,10 +32,10 @@
 
 .grid-row
   .column-full
-    %h2.heading-medium
-      = t('.heading_google')
+    %h1.heading-medium
+      = t('.heading_ditsso')
     %p
-      = t('.body_google')
+      = t('.body_ditsso')
     %p
       = link_to t('.log_in_google'), "/auth/ditsso_internal", class: 'button login-button'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,9 @@ module Peoplefinder
 
     config.department_abbrev = 'DIT'
 
+    # disable token authentication (hides fields from login page)
+    config.disable_token_auth = !ENV['ENABLE_TOKEN_AUTH'].nil?
+
     config.admin_ip_ranges = ENV.fetch('ADMIN_IP_RANGES', '127.0.0.1')
 
     config.readonly_ip_whitelist = ENV.fetch('READONLY_IP_WHITELIST', '127.0.0.1')

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,7 @@
+require 'ditsso_internal'
+
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :gplus, ENV['GPLUS_CLIENT_ID'], ENV['GPLUS_CLIENT_SECRET'],
-    scope: 'openid,profile,email'
+  provider 'ditsso_internal',
+    ENV['DITSSO_INTERNAL_CLIENT_ID'],
+    ENV['DITSSO_INTERNAL_CLIENT_SECRET']
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,9 +47,9 @@ en:
       intro_unauthorised: |
         For security reasons, you have to be logged in to People Finder to make any changes.
         We will email you a secure link so you can log in. This link will be active for %{ttl}.
-      heading_google: Got a government Google account?
-      body_google:
-        If you have a Google account ending in gov.uk, you can log in now.
+      heading_ditsso: Got a DIT account?
+      body_ditsso:
+        If you have a DIT account ending in trade.gov.uk, you can log in now.
       heading_other: Enter your DIT email address
       log_in_google: Log in
       log_in_email: Request link

--- a/lib/ditsso_internal.rb
+++ b/lib/ditsso_internal.rb
@@ -1,0 +1,40 @@
+module OmniAuth
+  module Strategies
+    class DitssoInternal < OmniAuth::Strategies::OAuth2
+      option :name, 'ditsso_internal'
+
+      SSO_PROVIDER = ENV['DITSSO_INTERNAL_PROVIDER']
+
+      option :client_options,
+        site:          SSO_PROVIDER,
+        authorize_url: "#{SSO_PROVIDER}/o/authorize/",
+        token_url: "#{SSO_PROVIDER}/o/token/"
+
+      uid do
+        raw_info['id']
+      end
+
+      info do
+        {
+          first_name: raw_info['first_name'],
+          last_name: raw_info['last_name'],
+          email: raw_info['email'].downcase
+        }
+      end
+
+      extra do
+        {
+          raw_info: raw_info
+        }
+      end
+
+      def raw_info
+        @raw_info ||= access_token.get('/api/v1/user/me/').parsed
+      end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
+    end
+  end
+end

--- a/spec/controllers/person_email_controller_spec.rb
+++ b/spec/controllers/person_email_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PersonEmailController, type: :controller do
   let(:token) { create(:token, user_email: new_email, spent: true) }
   let(:oauth_hash) do
     OmniAuth::AuthHash.new(
-      provider: 'gplus',
+      provider: 'ditsso_internal',
       info: {
         email: new_email,
         first_name: 'John',

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SessionsController, type: :controller do
 
   let(:john_doe_omniauth_hash) do
     OmniAuth::AuthHash.new(
-      provider: 'gplus',
+      provider: 'ditsso_internal',
       info: {
         email: 'john.doe@digital.justice.gov.uk',
         first_name: 'John',
@@ -21,7 +21,7 @@ RSpec.describe SessionsController, type: :controller do
 
   let(:john_doe2_omniauth_hash) do
     OmniAuth::AuthHash.new(
-      provider: 'gplus',
+      provider: 'ditsso_internal',
       info: {
         email: 'john.doe2@digital.justice.gov.uk',
         first_name: 'John',
@@ -33,7 +33,7 @@ RSpec.describe SessionsController, type: :controller do
 
   let(:fred_bloggs_omniauth_hash) do
     OmniAuth::AuthHash.new(
-      provider: 'gplus',
+      provider: 'ditsso_internal',
       info: {
         email: 'fred.bloggs@digital.justice.gov.uk',
         first_name: 'Fred',
@@ -123,7 +123,7 @@ RSpec.describe SessionsController, type: :controller do
       context 'using invalid omniauth hash' do
         let(:invalid_omniauth_hash) do
           OmniAuth::AuthHash.new(
-            provider: 'gplus',
+            provider: 'ditsso_internal',
             info: {
               email: 'rogue.user@example.com',
               first_name: 'John',

--- a/spec/features/login_page_spec.rb
+++ b/spec/features/login_page_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'Login page' do
   include PermittedDomainHelper
+  include TokenAuthEnabler
 
   let(:login_page) { Pages::Login.new }
   let(:token_created_page) { Pages::TokenCreated.new }

--- a/spec/features/omni_auth_authentication_spec.rb
+++ b/spec/features/omni_auth_authentication_spec.rb
@@ -15,7 +15,7 @@ feature 'OmniAuth Authentication' do
   end
 
   scenario 'Logging in and out' do
-    OmniAuth.config.mock_auth[:gplus] = valid_user
+    OmniAuth.config.mock_auth[:ditsso_internal] = valid_user
 
     visit '/'
     expect(login_page).to be_displayed
@@ -29,7 +29,7 @@ feature 'OmniAuth Authentication' do
   end
 
   scenario 'Log in failure' do
-    OmniAuth.config.mock_auth[:gplus] = invalid_user
+    OmniAuth.config.mock_auth[:ditsso_internal] = invalid_user
 
     visit '/'
     expect(login_page).to be_displayed
@@ -43,7 +43,7 @@ feature 'OmniAuth Authentication' do
   end
 
   scenario 'Non existent users are redirected to their new profiles edit page after logging in' do
-    OmniAuth.config.mock_auth[:gplus] = valid_user
+    OmniAuth.config.mock_auth[:ditsso_internal] = valid_user
     visit group_path(group)
     click_link 'Log in'
     expect(edit_profile_page).to be_displayed
@@ -51,7 +51,7 @@ feature 'OmniAuth Authentication' do
 
   scenario 'Existing users are redirected to their desired path after logging in' do
     create(:person, email: valid_user[:info][:email])
-    OmniAuth.config.mock_auth[:gplus] = valid_user
+    OmniAuth.config.mock_auth[:ditsso_internal] = valid_user
     visit group_path(group)
     click_link 'Log in'
     expect(group_page).to be_displayed
@@ -60,7 +60,7 @@ end
 
 def invalid_user
   OmniAuth::AuthHash.new(
-    provider: 'gplus',
+    provider: 'ditsso_internal',
     info: {
       email: 'test.user@example.com',
       first_name: 'John',
@@ -72,7 +72,7 @@ end
 
 def valid_user
   OmniAuth::AuthHash.new(
-    provider: 'gplus',
+    provider: 'ditsso_internal',
     info: {
       email: 'test.user@digital.justice.gov.uk',
       first_name: 'John',

--- a/spec/support/login.rb
+++ b/spec/support/login.rb
@@ -16,8 +16,8 @@ module SpecSupport
     def omni_auth_log_in_as(email)
       OmniAuth.config.test_mode = true
 
-      OmniAuth.config.mock_auth[:gplus] = OmniAuth::AuthHash.new(
-        provider: 'gplus',
+      OmniAuth.config.mock_auth[:ditsso_internal] = OmniAuth::AuthHash.new(
+        provider: 'ditsso_internal',
         info: {
           email: email,
           first_name: 'John',
@@ -26,7 +26,7 @@ module SpecSupport
         }
       )
 
-      visit 'auth/gplus'
+      visit 'auth/ditsso_internal'
     end
 
     def token_log_in_as(email)

--- a/spec/support/pages/person_confirm.rb
+++ b/spec/support/pages/person_confirm.rb
@@ -3,7 +3,7 @@ require_relative 'sections/person_confirm_search_results'
 
 module Pages
   class PersonConfirm < Base
-    set_url_matcher(%r{[tokens/.*|/auth/gplus]})
+    set_url_matcher(%r{[tokens/.*|/auth/ditsso_internal]})
 
     section :person_confirm_results, Sections::PersonConfirmSearchResults, '#confirm-person-results'
     section :form, Sections::PersonConfirmForm, '.new_person'

--- a/spec/support/token_auth_enabler.rb
+++ b/spec/support/token_auth_enabler.rb
@@ -1,0 +1,12 @@
+# Token authentication is disabled by default.
+# Here we enable it for the tests that have
+# been built around token authentication
+module TokenAuthEnabler
+  extend ActiveSupport::Concern
+
+  included do
+    before do
+      ENV['ENABLE_TOKEN_AUTH'] = 'YES PLEASE!'
+    end
+  end
+end


### PR DESCRIPTION
This PR replaces the google omniauth provider with the DIT's SSO provider.

Not to be merged into until we have an environment that allows multiple users to authenticated against the live provider.