### PR TITLE
Allow users from any domain to have an account

### DIFF
--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -14,6 +14,7 @@ class EmailAddress
   end
 
   def permitted_domain?
+    return true if Rails.configuration.disable_permitted_domain_checks
     valid_login_domains.any? { |pattern| pattern === domain }
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,9 @@ module Peoplefinder
     # disable token authentication (hides fields from login page)
     config.disable_token_auth = true
 
+    # disable permitted domain checks (allows user from any domain)
+    config.disable_permitted_domain_checks = true
+
     config.admin_ip_ranges = ENV.fetch('ADMIN_IP_RANGES', '127.0.0.1')
 
     config.readonly_ip_whitelist = ENV.fetch('READONLY_IP_WHITELIST', '127.0.0.1')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,4 +23,5 @@ Rails.application.configure do
   # enable these features just for tests
   config.disable_token_auth = false
   config.disable_organogram = false
+  config.disable_permitted_domain_checks = false
 end

--- a/spec/models/email_address_spec.rb
+++ b/spec/models/email_address_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe EmailAddress do
   end
 
   describe '.permitted_domain' do
+    context 'when disable_permitted_domain_checks = true' do
+      it "allows any domain" do
+        Rails.configuration.disable_permitted_domain_checks = true
+        expect(described_class.new('me@example.com')).to be_permitted_domain
+        Rails.configuration.disable_permitted_domain_checks = false
+      end
+    end
+
     context 'with strings to match login domains' do
       let(:permitted_login_domains) { ['dept.gov.uk'] }
 


### PR DESCRIPTION
- Here we disable the permitted_domains feature
as we don’t know what domains the DIT users will
come from.