### PR TITLE
Explicitly declare the SSO Callback URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ GECKOBOARD_API_KEY=moj_geckoboard_api_key
 DITSSO_INTERNAL_PROVIDER=
 DITSSO_INTERNAL_CLIENT_ID=localdev_ditsso_client_id
 DITSSO_INTERNAL_CLIENT_SECRET=localdev_ditsso_client_secret
+DITSSO_CALLBACK_URL=http://localhost:3000/auth/ditsso_internal/callback
+
 SSL_ON=false
 GA_TRACKING_ID=UA-XXXXX-X
 MAX_TOKENS_PER_HOUR=8

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Authentication to Log in to People Finder in the various environments (dev/stagi
 `DITSSO_INTERNAL_PROVIDER`
 `DITSSO_INTERNAL_CLIENT_ID`
 `DITSSO_INTERNAL_CLIENT_SECRET`
+Note that due to Cloudfoundry's routing we can't use the omniauth helpers to build the callback URL. We have to explicitly declare it as:
+`DITSSO_CALLBACK_URL`
+
 
 ## Token-based authentication
 

--- a/lib/ditsso_internal.rb
+++ b/lib/ditsso_internal.rb
@@ -33,7 +33,7 @@ module OmniAuth
       end
 
       def callback_url
-        full_host + script_name + callback_path
+        ENV['DITSSO_CALLBACK_URL']
       end
     end
   end


### PR DESCRIPTION
-  due to Cloudfoundry's routing we can't use the 
omniauth helpers to build the callback URL.