### PR TITLE
Set provider_ignores_state = true

### DIFF
--- a/lib/ditsso_internal.rb
+++ b/lib/ditsso_internal.rb
@@ -2,6 +2,7 @@ module OmniAuth
   module Strategies
     class DitssoInternal < OmniAuth::Strategies::OAuth2
       option :name, 'ditsso_internal'
+      option :provider_ignores_state, true
 
       SSO_PROVIDER = ENV['DITSSO_INTERNAL_PROVIDER']
 


### PR DESCRIPTION
- Brute force debugging of the auth cloud front issue. 

- However, we are skipping the check for the omniauth state attribute.