### PR TITLE
Tidy up oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,6 @@ Authentication to Log in to People Finder in the various environments (dev/stagi
 `DITSSO_INTERNAL_PROVIDER`
 `DITSSO_INTERNAL_CLIENT_ID`
 `DITSSO_INTERNAL_CLIENT_SECRET`
-Note that due to Cloudfoundry's routing we can't use the omniauth helpers to build the callback URL. We have to explicitly declare it as:
-`DITSSO_CALLBACK_URL`
-
 
 ## Token-based authentication
 

--- a/lib/ditsso_internal.rb
+++ b/lib/ditsso_internal.rb
@@ -34,7 +34,7 @@ module OmniAuth
       end
 
       def callback_url
-        ENV.fetch('DITSSO_CALLBACK_URL', full_host + script_name + callback_path)
+        full_host + script_name + callback_path
       end
     end
   end

--- a/lib/ditsso_internal.rb
+++ b/lib/ditsso_internal.rb
@@ -29,6 +29,10 @@ module OmniAuth
       end
 
       def raw_info
+        # Here we are skipping the verification of the 'code' param
+        # as it seems to be a requirement of the live sso provider.
+        # This is based on the demo applicaion provided as:
+        # https://github.com/uktrade/rails-abc-example/blob/master/lib/ditsso_internal.rb#L33
         access_token_path = "/api/v1/user/me/?access_token=#{access_token.token}"
         @raw_info ||= access_token.get(access_token_path).parsed
       end


### PR DESCRIPTION
Here we revert the workarounds that were implemented due to the behaviour of URL forwarding in the production environment.