### PR TITLE
Build identity_auth_key

### DIFF
--- a/app/controllers/api/people_controller.rb
+++ b/app/controllers/api/people_controller.rb
@@ -13,7 +13,7 @@ module Api
     private
 
     def set_person
-      @person = Person.includes(:groups).find_by(email: params[:email])
+      @person = Person.includes(:groups).find_by(internal_auth_email: params[:email])
     end
   end
 end

--- a/app/controllers/api/people_controller.rb
+++ b/app/controllers/api/people_controller.rb
@@ -13,7 +13,7 @@ module Api
     private
 
     def set_person
-      @person = Person.includes(:groups).find_by(internal_auth_email: params[:email])
+      @person = Person.includes(:groups).find_by(internal_auth_key: params[:email])
     end
   end
 end

--- a/app/controllers/concerns/session_person_creator.rb
+++ b/app/controllers/concerns/session_person_creator.rb
@@ -6,6 +6,7 @@ module SessionPersonCreator
       email = EmailAddress.new(auth_hash['info']['email'])
       return unless email.permitted_domain?
       find_or_create_person(email) do |new_person|
+        new_person.email = email
         new_person.given_name = auth_hash['info']['first_name']
         new_person.surname = auth_hash['info']['last_name']
       end
@@ -14,6 +15,7 @@ module SessionPersonCreator
     def person_from_token(token)
       email = EmailAddress.new(token.user_email)
       find_or_create_person(email) do |new_person|
+        new_person.email = email
         new_person.given_name = email.inferred_first_name
         new_person.surname = email.inferred_last_name
       end
@@ -32,7 +34,7 @@ module SessionPersonCreator
     private
 
     def find_or_create_person(email, &_on_create)
-      person = Person.where(email: email.to_s).first_or_initialize
+      person = Person.where(internal_auth_key: email.to_s).first_or_initialize
       yield(person) if person.new_record?
       person
     end

--- a/db/migrate/20171106164424_add_internal_auth_email_to_people.rb
+++ b/db/migrate/20171106164424_add_internal_auth_email_to_people.rb
@@ -1,0 +1,5 @@
+class AddInternalAuthEmailToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :internal_auth_email, :string, index: true
+  end
+end

--- a/db/migrate/20171106164424_add_internal_auth_email_to_people.rb
+++ b/db/migrate/20171106164424_add_internal_auth_email_to_people.rb
@@ -1,5 +1,5 @@
 class AddInternalAuthEmailToPeople < ActiveRecord::Migration
   def change
-    add_column :people, :internal_auth_email, :string, index: true
+    add_column :people, :internal_auth_key, :string, index: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -105,7 +105,7 @@ ActiveRecord::Schema.define(version: 20171106164424) do
     t.string   "additional_responsibilities", default: [],                 array: true
     t.text     "other_uk"
     t.text     "other_overseas"
-    t.string   "internal_auth_email"
+    t.string   "internal_auth_key"
   end
 
   add_index "people", ["slug"], name: "index_people_on_slug", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171030121949) do
+ActiveRecord::Schema.define(version: 20171106164424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 20171030121949) do
     t.string   "additional_responsibilities", default: [],                 array: true
     t.text     "other_uk"
     t.text     "other_overseas"
+    t.string   "internal_auth_email"
   end
 
   add_index "people", ["slug"], name: "index_people_on_slug", unique: true, using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,6 +2,7 @@
 FactoryGirl.define do
 
   sequence(:email) { |n| 'example.user.%d@digital.justice.gov.uk' % n }
+  sequence(:internal_auth_email) { |n| 'internal.auth.user.%dexample.com' % n }
   sequence(:given_name) { |n| "First name #{('a'.ord + (n % 25)).chr}" }
   sequence(:surname) { |n| "Surname #{('a'.ord + (n % 25)).chr}" }
   sequence(:location_in_building) { |n| "Room #{n}, #{n.ordinalize}" }
@@ -57,6 +58,10 @@ FactoryGirl.define do
       country
       location_in_building
       city
+    end
+
+    trait :with_internal_auth_email do
+      internal_auth_email
     end
 
     trait :with_random_dets do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -45,6 +45,7 @@ FactoryGirl.define do
     given_name
     surname
     email
+    internal_auth_email
 
     # validation requires team membership existence
     after :build do |peep, _evaluator|
@@ -58,10 +59,6 @@ FactoryGirl.define do
       country
       location_in_building
       city
-    end
-
-    trait :with_internal_auth_email do
-      internal_auth_email
     end
 
     trait :with_random_dets do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,7 +2,7 @@
 FactoryGirl.define do
 
   sequence(:email) { |n| 'example.user.%d@digital.justice.gov.uk' % n }
-  sequence(:internal_auth_email) { |n| 'internal.auth.user.%dexample.com' % n }
+  sequence(:internal_auth_key) { |n| 'internal.auth.user.%dexample.com' % n }
   sequence(:given_name) { |n| "First name #{('a'.ord + (n % 25)).chr}" }
   sequence(:surname) { |n| "Surname #{('a'.ord + (n % 25)).chr}" }
   sequence(:location_in_building) { |n| "Room #{n}, #{n.ordinalize}" }
@@ -45,7 +45,7 @@ FactoryGirl.define do
     given_name
     surname
     email
-    internal_auth_email
+    internal_auth_key
 
     # validation requires team membership existence
     after :build do |peep, _evaluator|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,7 +2,6 @@
 FactoryGirl.define do
 
   sequence(:email) { |n| 'example.user.%d@digital.justice.gov.uk' % n }
-  sequence(:internal_auth_key) { |n| 'internal.auth.user.%dexample.com' % n }
   sequence(:given_name) { |n| "First name #{('a'.ord + (n % 25)).chr}" }
   sequence(:surname) { |n| "Surname #{('a'.ord + (n % 25)).chr}" }
   sequence(:location_in_building) { |n| "Room #{n}, #{n.ordinalize}" }
@@ -45,12 +44,15 @@ FactoryGirl.define do
     given_name
     surname
     email
-    internal_auth_key
 
     # validation requires team membership existence
     after :build do |peep, _evaluator|
       department = create(:department)
       peep.memberships << build(:membership, group: department, person: nil) if peep.memberships.empty?
+
+      # ensure that the internal_auth_email is populated
+      # so an oauth user can be logged in
+      peep.internal_auth_key = peep.email
     end
 
     trait :with_details do

--- a/spec/models/queued_notification_spec.rb
+++ b/spec/models/queued_notification_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe QueuedNotification, type: :model do
               'given_name' => [nil, 'Stephen'],
               'surname' => [nil, 'Jones'],
               'email' => [nil, 'sr@digital.justice.gov.uk'],
+              'internal_auth_key'=>[nil, 'sr@digital.justice.gov.uk'],
               'slug' => [nil, 'stephen-richards'],
               "membership_#{@moj.id}" => {
                 "group_id" => [nil, @moj.id]
@@ -138,6 +139,7 @@ RSpec.describe QueuedNotification, type: :model do
               'given_name'=>[nil, 'John'],
               'surname'=>[nil, 'Jones'],
               'email'=>[nil, 'john.jones@digital.justice.gov.uk'],
+              'internal_auth_key'=>[nil, 'sr@digital.justice.gov.uk'],
               'slug'=>[nil, 'stephen-richards'],
               'works_friday'=>[true, false],
               "membership_#{@moj.id}" => {

--- a/spec/requests/person_profile_spec.rb
+++ b/spec/requests/person_profile_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Person Profile API', type: :request do
   include PermittedDomainHelper
 
-  let(:person) { create(:person, :with_photo, :team_member) }
+  let(:person) { create(:person, :with_internal_auth_email, :with_photo, :team_member) }
 
   let(:parsed_json) { JSON.parse(response.body).with_indifferent_access }
   let(:attr_hash) { parsed_json['data']['attributes'] }
@@ -11,7 +11,7 @@ describe 'Person Profile API', type: :request do
   let(:profile_image_url_hash_key) { 'profile-image-url' }
 
   before do
-    get "/api/people?email=#{person.email}",
+    get "/api/people?email=#{person.internal_auth_email}",
       {},
       authorization: "Token #{ENV['PROFILE_API_TOKEN']}"
   end
@@ -41,7 +41,7 @@ describe 'Person Profile API', type: :request do
   end
 
   context 'with no profile image' do
-    let(:person) { create(:person) }
+    let(:person) { create(:person, internal_auth_email: 'alice@example.com') }
 
     it 'does not have the profile-image-url' do
       expect(links_hash[profile_image_url_hash_key]).to be_blank
@@ -49,7 +49,7 @@ describe 'Person Profile API', type: :request do
   end
 
   context 'when the person is not found' do
-    let(:person) { double(:person, email: 'not-found@example.com') }
+    let(:person) { double(:person, internal_auth_email: 'not-found@example.com') }
 
     it 'returns a 404' do
       expect(response.status).to eq(404)

--- a/spec/requests/person_profile_spec.rb
+++ b/spec/requests/person_profile_spec.rb
@@ -11,7 +11,7 @@ describe 'Person Profile API', type: :request do
   let(:profile_image_url_hash_key) { 'profile-image-url' }
 
   before do
-    get "/api/people?email=#{person.internal_auth_email}",
+    get "/api/people?email=#{person.internal_auth_key}",
       {},
       authorization: "Token #{ENV['PROFILE_API_TOKEN']}"
   end
@@ -49,7 +49,7 @@ describe 'Person Profile API', type: :request do
   end
 
   context 'when the person is not found' do
-    let(:person) { double(:person, internal_auth_email: 'nobody@example.com') }
+    let(:person) { double(:person, internal_auth_key: 'nobody@example.com') }
 
     it 'returns a 404' do
       expect(response.status).to eq(404)

--- a/spec/requests/person_profile_spec.rb
+++ b/spec/requests/person_profile_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Person Profile API', type: :request do
   include PermittedDomainHelper
 
-  let(:person) { create(:person, :with_internal_auth_email, :with_photo, :team_member) }
+  let(:person) { create(:person, :with_photo, :team_member) }
 
   let(:parsed_json) { JSON.parse(response.body).with_indifferent_access }
   let(:attr_hash) { parsed_json['data']['attributes'] }
@@ -41,7 +41,7 @@ describe 'Person Profile API', type: :request do
   end
 
   context 'with no profile image' do
-    let(:person) { create(:person, internal_auth_email: 'alice@example.com') }
+    let(:person) { create(:person) }
 
     it 'does not have the profile-image-url' do
       expect(links_hash[profile_image_url_hash_key]).to be_blank
@@ -49,7 +49,7 @@ describe 'Person Profile API', type: :request do
   end
 
   context 'when the person is not found' do
-    let(:person) { double(:person, internal_auth_email: 'not-found@example.com') }
+    let(:person) { double(:person, internal_auth_email: 'nobody@example.com') }
 
     it 'returns a 404' do
       expect(response.status).to eq(404)


### PR DESCRIPTION
When authenticating against the SSO we will store the email returned by the SSO provider as the internal_auth_key. This leaves the email address as a cosmetic garnish that can be edited as desired.