### PR TITLE
Remove 'add sub team' link from the edit profile page

### DIFF
--- a/app/views/people/_team_selector.html.haml
+++ b/app/views/people/_team_selector.html.haml
@@ -20,7 +20,8 @@
     - if @org_structure
       = render 'shared/org_browser', org_structure: @org_structure, form: membership_f, field_name: :group_id
       = link_to 'Done', '#', class: 'hide-editable-fields button-secondary'
-      = link_to 'Add new sub-team to the <span class="team-led"></span>'.html_safe, '#', class: 'button-add-team'
+      - if can_edit_profiles?
+        = link_to 'Add new sub-team to the <span class="team-led"></span>'.html_safe, '#', class: 'button-add-team'
       %div.new-team
         = membership_f.label 'addteam', 'Add new sub-team to the <span class="team-led"></span>'.html_safe, class: 'form-label-bold'
         %input.form-control.new-team-name#AddTeam


### PR DESCRIPTION
- We are not allowing users to edit teams on this page