### PR TITLE
Allow users to request profile deletion

### DIFF
--- a/app/assets/stylesheets/modules/_module-media.scss
+++ b/app/assets/stylesheets/modules/_module-media.scss
@@ -236,4 +236,8 @@
       font-size: 16px;
     }
   }
+
+  .deletion-request-link {
+    font-size: 16px;
+  }
 }

--- a/app/controllers/person_deletion_request_controller.rb
+++ b/app/controllers/person_deletion_request_controller.rb
@@ -1,0 +1,24 @@
+class PersonDeletionRequestController < ApplicationController
+
+  before_action :set_person
+
+  def new; end
+
+  def create
+    PersonDeletionRequestMailer.deletion_request(
+      reporter: current_user,
+      person: @person,
+      note: params[:note]
+    ).deliver_now
+
+    notice(:request_sent)
+    redirect_to person_path(@person)
+  end
+
+  private
+
+  def set_person
+    @person = Person.friendly.find(params[:person_id])
+  end
+
+end

--- a/app/mailers/person_deletion_request_mailer.rb
+++ b/app/mailers/person_deletion_request_mailer.rb
@@ -1,0 +1,12 @@
+class PersonDeletionRequestMailer < ActionMailer::Base
+  layout 'email'
+
+  def deletion_request(reporter:, person:, note:)
+    @reporter = reporter
+    @person = person
+    @note = note
+
+    mail to: Rails.configuration.support_email,
+      reply_to: reporter.email
+  end
+end

--- a/app/views/people/_profile.html.haml
+++ b/app/views/people/_profile.html.haml
@@ -22,6 +22,8 @@
               = render partial: "completeness", locals: { person: @person }
             - if can_edit_profiles?
               = render partial: "request_information", locals: { person: @person }
+        %p.deletion-request-link
+          = link_to("Has #{@person.given_name} left the department?", new_person_deletion_request_path(@person))
       .media-body
         %h4.media-heading
         - @person.memberships.group_by(&:group).each do |group, memberships|

--- a/app/views/person_deletion_request/_breadcrumbs.html.haml
+++ b/app/views/person_deletion_request/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+- content_for :breadcrumbs do
+  = breadcrumbs(Home.path + @person.path)

--- a/app/views/person_deletion_request/new.html.haml
+++ b/app/views/person_deletion_request/new.html.haml
@@ -1,0 +1,26 @@
+- content_for :body_classes, 'profile-page-request-deletion '
+
+= render partial: 'breadcrumbs'
+
+.grid-row.mod-heading
+  .column-full
+    %h1.heading-xlarge.mod-heading-border
+      = @page_title = 'Request deletion of this profile'
+      %span.pull-right
+        = link_to 'Cancel and go to profile page', @person,{ class: 'font-xsmall' }
+
+.grid-row.mod-media.profile
+  .column-full
+    %p
+      = t('person_deletion_request.instruction', name: @person.name)
+
+    = form_tag person_deletion_request_path(@person) do
+
+      .form-group
+        = text_area_tag :note, '', { class: 'form-control' }
+
+      %p
+        = t('person_deletion_request.your_details_hint')
+
+      .form-group
+        = submit_tag 'Request deletion', { class: 'button' }

--- a/app/views/person_deletion_request_mailer/deletion_request.text.erb
+++ b/app/views/person_deletion_request_mailer/deletion_request.text.erb
@@ -1,0 +1,11 @@
+Profile deletion request
+
+Profile name: <%= @person.name %>
+Profile URL: <%= person_url(@person) %>
+
+Reported by: <%= @reporter.name %>
+Reporter email: <%= @reporter.email %>
+
+Note:
+
+"<%= @note %>"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,10 @@ en:
           We have let %{person} know that you’ve made changes
       profile_deleted: "Deleted %{person}’s profile"
       create_error: "The profile was not created. Please check the errors below"
+    person_deletion_request:
+      request_sent: |
+        Thank you for helping to improve People Finder.
+        We'll review this profile.
     person_image:
       no_image_uploaded: "No image has been uploaded for %{person}"
       image_cropped: "Cropped %{person}’s image"
@@ -353,6 +357,9 @@ en:
       line_number: Line
       messages: Error
       raw: Current content
+  person_deletion_request:
+    instruction: If %{name} has left the department, please provide details in the form below. Our support team will confirm the details and remove the profile.
+    your_details_hint: Your profile details will be included with the request.
   suggestions:
     thank_you_intro: Thank you for helping improve this profile.
     thank_you_detail:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
     resource :image, controller: 'person_image', only: [:edit, :update]
     resource :email, controller: 'person_email', only: [:edit, :update]
     resources :suggestions, only: [:new, :create]
+    resource :deletion_request, controller: 'person_deletion_request',
+                                path: 'deletion-request',
+                                only: [:new, :create]
   end
 
   resource :sessions, only: [:new, :create, :destroy] do

--- a/spec/controllers/person_deletion_request_controller_spec.rb
+++ b/spec/controllers/person_deletion_request_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe PersonDeletionRequestController, type: :controller do
+  include PermittedDomainHelper
+
+  before do
+    mock_logged_in_user
+  end
+
+  let(:person) { create(:person) }
+
+  describe 'GET new' do
+    it 'assigns the requested person as @person' do
+      get :new, person_id: person.to_param
+      expect(assigns(:person)).to eq(person)
+    end
+  end
+
+  describe 'POST create' do
+    it 'redirects to the profile page' do
+      post :create, person_id: person.to_param
+      expect(response).to redirect_to(person_path(person))
+    end
+
+    it 'invokes the mailer to send an email now' do
+      mock_mailer = double("PersonDeletionRequestMailer")
+
+      expect(PersonDeletionRequestMailer).to receive(:deletion_request).
+        with(
+          reporter: current_user,
+          person: person,
+          note: 'This is a note'
+        ).and_return(mock_mailer)
+
+      expect(mock_mailer).to receive(:deliver_now)
+
+      post :create, person_id: person.to_param, note: 'This is a note'
+    end
+  end
+
+end

--- a/spec/features/person_deletion_requests_spec.rb
+++ b/spec/features/person_deletion_requests_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+feature 'Sending deletion requests' do
+  include ActiveJobHelper
+  include PermittedDomainHelper
+
+  let(:requester) { create(:person, email: 'test.user@digital.justice.gov.uk') }
+  let(:person) { create(:person, email: 'gone.user@digital.justice.gov.uk') }
+
+  before do
+    omni_auth_log_in_as(requester.email)
+  end
+
+  scenario 'Requesting a person to be deleted' do
+    visit person_path(person)
+
+    click_on "Has #{person.given_name} left the department?"
+    fill_in 'note', with: 'They left the department in 2001.'
+
+    expect do
+      click_button 'Request deletion'
+    end.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+    expect(page).to have_content("We'll review this profile")
+
+    last_email = ActionMailer::Base.deliveries.last
+
+    expect(last_email.reply_to).to include(requester.email)
+    expect(last_email.to).to include(Rails.configuration.support_email)
+
+    expect(last_email.body).to have_text(requester.name)
+    expect(last_email.body).to have_text(requester.email)
+
+    expect(last_email.body).to have_text(person.name)
+    expect(last_email.body).to have_text(person_url(person))
+  end
+end

--- a/spec/mailers/person_deletion_request_mailer_spec.rb
+++ b/spec/mailers/person_deletion_request_mailer_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe PersonDeletionRequestMailer do
+  include PermittedDomainHelper
+
+  let(:reporter) { create(:person, email: 'test.user@digital.justice.gov.uk') }
+  let(:person) { create(:person) }
+  let(:reported) { Time.now.to_i }
+  let(:support_email) { Rails.configuration.support_email }
+  let(:details_hash) do
+    {
+      reporter: reporter,
+      person: person,
+      note: 'They left the department last week.'
+    }
+  end
+
+  describe '.deletion_request' do
+    let(:mail) do
+      described_class.deletion_request(details_hash).
+        deliver_now
+    end
+
+    it 'is sent to support mailbox' do
+      expect(mail.to).to include(support_email)
+    end
+
+    it 'sets reply-to to persons email for automated response' do
+      expect(mail.reply_to).to include(reporter.email)
+    end
+
+    it 'has text part only' do
+      expect(mail.multipart?).to be false
+      expect(mail.content_type).to include 'text/plain'
+    end
+
+    it 'includes the name of the reporter' do
+      expect(mail.body).to have_text(reporter.name)
+    end
+
+    it 'includes the email of the reporter' do
+      expect(mail.body).to have_text(reporter.email)
+    end
+
+    it 'includes the name of the person' do
+      expect(mail.body).to have_text(person.name)
+    end
+
+    it "includes the URL to the person's profile" do
+      expect(mail.body).to have_text(person_url(person))
+    end
+  end
+end


### PR DESCRIPTION
This branch allows users to request profiles to be deleted when people have left the organisation.

It adds a new form to the profile page, where users can add a note. When a request is submitted, it is sent by email to the support address defined in `SUPPORT_EMAIL` – the same address shared with the `ProblemReportMailer`.

Of note is that the email is sent immediately, rather than being queued for delivery. This is because the email notification is key to the interaction being completed, and I would prefer that this errors to the user rather than quietly fails.

## Screenshot 
<img width="945" alt="screen shot 2017-11-09 at 16 34 11" src="https://user-images.githubusercontent.com/71922/32617060-e5db0862-c56b-11e7-8c18-de1cb5d6bfb3.png">