### PR TITLE
Remove Mailcatcher from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ end
 
 group :development do
   gem 'foreman'
-  gem 'mailcatcher'
   gem 'spring-commands-rspec'
   gem 'rb-fsevent', require: RUBY_PLATFORM[/darwin/i].to_s.size > 0
   gem 'meta_request'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,6 @@ GEM
       addressable
     currencies (0.4.2)
     daemon (1.2.0)
-    daemons (1.2.4)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     delayed_job_active_record (4.1.1)
@@ -167,7 +166,6 @@ GEM
       multi_json
     equalizer (0.0.11)
     erubis (2.7.0)
-    eventmachine (1.0.9.1)
     excon (0.45.1)
     execjs (2.6.0)
     factory_girl (4.8.0)
@@ -383,14 +381,6 @@ GEM
     lumberjack (1.0.9)
     mail (2.6.6.rc1)
       mime-types (>= 1.16, < 4)
-    mailcatcher (0.6.5)
-      eventmachine (= 1.0.9.1)
-      mail (~> 2.3)
-      rack (~> 1.5)
-      sinatra (~> 1.2)
-      skinny (~> 0.2.3)
-      sqlite3 (~> 1.3)
-      thin (~> 1.5.0)
     meta_request (0.4.2)
       callsite (~> 0.0, >= 0.0.11)
       rack-contrib (~> 1.1)
@@ -465,8 +455,6 @@ GEM
     rack-contrib (1.4.0)
       git-version-bump (~> 0.15)
       rack (~> 1.4)
-    rack-protection (1.5.3)
-      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.8)
@@ -559,16 +547,9 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
     site_prism (2.9)
       addressable (>= 2.3.3, < 3.0)
       capybara (>= 2.1, < 3.0)
-    skinny (0.2.4)
-      eventmachine (~> 1.0.0)
-      thin (>= 1.5, < 1.7)
     slop (3.6.0)
     sort_alphabetical (1.0.2)
       unicode_utils (>= 1.2.2)
@@ -582,12 +563,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     text (1.3.1)
-    thin (1.5.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -678,7 +654,6 @@ DEPENDENCIES
   launchy
   logstasher (~> 0.6.2)
   mail (~> 2.6.6.rc1)
-  mailcatcher
   meta_request
   mini_magick
   minitest
@@ -724,4 +699,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/README.md
+++ b/README.md
@@ -72,10 +72,13 @@ cd peoplefinder
 bundle exec rake jobs:work
 ```
 
-To catch emails in development, in a separate terminal, run `mailcatcher` and view emails at `http://localhost:1080`:
+To catch emails in development, in a separate terminal, install the
+[mailcatcher](https://github.com/sj26/mailcatcher) gem. Run `mailcatcher` and
+view emails at `http://localhost:1080`:
 
 ```cmd
 cd peoplefinder
+gem install mailcatcher
 mailcatcher
 ```
 


### PR DESCRIPTION
The Mailcatcher README advises against including it in your Gemfile, and this is what's causing our asset builds to fail.

This commit removes it from the Gemfile and adds a note to our README.