### PR TITLE
Update profile editing and deletion permissions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -180,6 +180,7 @@ Rails/ScopeArgs:
 
 RSpec/ScatteredSetup:
   Exclude:
+    - 'spec/controllers/people_controller_spec.rb'
     - 'spec/features/group_maintenance_spec.rb'
     - 'spec/features/management_spec.rb'
     - 'spec/features/person_maintenance_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -177,3 +177,10 @@ RSpec/InstanceVariable:
 
 Rails/ScopeArgs:
   Enabled: false
+
+RSpec/ScatteredSetup:
+  Exclude:
+    - 'spec/features/group_maintenance_spec.rb'
+    - 'spec/features/management_spec.rb'
+    - 'spec/features/person_maintenance_spec.rb'
+    - 'spec/features/suggestion_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -183,5 +183,6 @@ RSpec/ScatteredSetup:
     - 'spec/controllers/people_controller_spec.rb'
     - 'spec/features/group_maintenance_spec.rb'
     - 'spec/features/management_spec.rb'
+    - 'spec/features/person_edit_notifications_spec.rb'
     - 'spec/features/person_maintenance_spec.rb'
     - 'spec/features/suggestion_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -249,14 +249,6 @@ RSpec/ScatteredLet:
     - 'spec/mailers/only_send_login_email_interceptor_spec.rb'
     - 'spec/presenters/membership_changes_presenter_spec.rb'
 
-# Offense count: 8
-RSpec/ScatteredSetup:
-  Exclude:
-    - 'spec/features/group_maintenance_spec.rb'
-    - 'spec/features/management_spec.rb'
-    - 'spec/features/person_maintenance_spec.rb'
-    - 'spec/features/suggestion_spec.rb'
-
 # Offense count: 12
 RSpec/SubjectStub:
   Exclude:

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -24,7 +24,7 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def destroy?
-    regular_user?
+    admin_user?
   end
 
   def add_membership?

--- a/app/views/group_update_mailer/inform_subscriber.html.haml
+++ b/app/views/group_update_mailer/inform_subscriber.html.haml
@@ -3,9 +3,9 @@
     Hello #{@person.given_name},
 %tr
   %td{ align:"left", valign: "top", style: "line-height: 30px; padding-bottom:20px;", width: "560" }
-    The #{@group} page on People Finder has been edited by #{ mail_to @instigator.email }.
+    The #{@group} page on People Finder has been edited and republished by #{ mail_to @instigator.email }.
     %p
-      Check the team's profile:
+      View the updated details:
     = browser_warning
     = easy_copy_link_to url: @group_url
     = app_guidance

--- a/app/views/people/_action_links.haml
+++ b/app/views/people/_action_links.haml
@@ -1,10 +1,11 @@
 - if @person.persisted?
   - if can_edit_profiles?
-    = link_to info_text('delete_this_profile'),
-      @person,
-      method: :delete,
-      class: "button button-secondary",
-      data: { confirm: "Are you sure you want to delete #{ @person }? #{ info_text('profile_deletable') }." }
+    - if policy(@person).destroy?
+      = link_to info_text('delete_this_profile'),
+        @person,
+        method: :delete,
+        class: "button button-secondary",
+        data: { confirm: "Are you sure you want to delete #{ @person }? #{ info_text('profile_deletable') }." }
     = edit_person_link 'Edit this profile', @person, class: 'button'
   - elsif @person == current_user
     = edit_person_link 'Edit my profile', current_user, class: 'button'

--- a/app/views/user_update_mailer/deleted_profile_email.html.haml
+++ b/app/views/user_update_mailer/deleted_profile_email.html.haml
@@ -4,7 +4,7 @@
 %tr
   %td{ align:"left", valign: "top", style: "line-height: 30px;", width: "560" }
     %p
-      The People Finder profile linked to this email address has been deleted
+      The People Finder profile linked to your email address has been deleted
       - if @by_email.present?
         by #{ mail_to @by_email }.
     %p

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,7 @@ module Peoplefinder
     config.disable_permitted_domain_checks = true
 
     # disabling the adding/editing/deletion of another person's profile
-    config.disable_open_profiles = true
+    config.disable_open_profiles = false
 
     config.admin_ip_ranges = ENV.fetch('ADMIN_IP_RANGES', '127.0.0.1')
 

--- a/spec/features/flash_spec.rb
+++ b/spec/features/flash_spec.rb
@@ -14,9 +14,10 @@ feature 'Flash messages' do
     let(:person) { create :person }
     let(:flash_messages) { 'flash-messages' }
     let(:searchbox) { 'mod-search-form' }
+    let(:super_admin) { create(:super_admin) }
 
     before do
-      omni_auth_log_in_as 'test.user@digital.justice.gov.uk'
+      omni_auth_log_in_as super_admin.email
       person.memberships.destroy_all
     end
 

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -6,6 +6,7 @@ feature 'Person maintenance' do
 
   let(:department) { create(:department) }
   let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
+  let(:super_admin) { create(:super_admin, email: 'super.admin@digital.justice.gov.uk') }
   let(:another_person) { create(:person, email: 'someone.else@digital.justice.gov.uk') }
 
   before do
@@ -14,6 +15,10 @@ feature 'Person maintenance' do
 
   before(:each, user: :regular) do
     omni_auth_log_in_as person.email
+  end
+
+  before(:each, user: :super_admin) do
+    omni_auth_log_in_as super_admin.email
   end
 
   before(:each, user: :readonly) do
@@ -352,7 +357,7 @@ feature 'Person maintenance' do
   end
 
   context 'Deleting a person' do
-    context 'for a regular user', user: :regular do
+    context 'for a super admin user', user: :super_admin do
       scenario 'Deleting a person' do
         person = create :person
         email_address = person.email

--- a/spec/features/regression_spec.rb
+++ b/spec/features/regression_spec.rb
@@ -6,7 +6,7 @@ feature 'Regression' do
   let(:login_page) { Pages::Login.new }
 
   before do
-    omni_auth_log_in_as 'test.user@digital.justice.gov.uk'
+    omni_auth_log_in_as create(:super_admin).email
   end
 
   scenario 'Gracefully handle a session when the logged in person deletes their profile' do

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -13,8 +13,14 @@ RSpec.describe PersonPolicy, type: :policy do
     it { is_expected.to permit_action(:update) }
     it { is_expected.to permit_action(:new) }
     it { is_expected.to permit_action(:create) }
-    it { is_expected.to permit_action(:destroy) }
+    it { is_expected.not_to permit_action(:destroy) }
     it { is_expected.to permit_action(:add_membership) }
+  end
+
+  context 'for a super admin user' do
+    let(:user) { build_stubbed(:super_admin) }
+
+    it { is_expected.to permit_action(:destroy) }
   end
 
   context 'for the readonly user' do


### PR DESCRIPTION
This branch changes the editing and deletion permissions for People Finder profiles.

It re-enables editing of profiles by any user, now that email notifications are being sent out (#51). It also restricts deletion of profiles to super admins, now that users can request profiles to be deleted (#46).

This also includes some minor content changes to email notifications, and updates tests to reflect the new permission changes.