### PR TITLE
Restrict group modifications to super admins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -185,4 +185,5 @@ RSpec/ScatteredSetup:
     - 'spec/features/management_spec.rb'
     - 'spec/features/person_edit_notifications_spec.rb'
     - 'spec/features/person_maintenance_spec.rb'
+    - 'spec/features/person_membership_spec.rb'
     - 'spec/features/suggestion_spec.rb'

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -4,22 +4,22 @@ class GroupPolicy < ApplicationPolicy
   end
 
   def edit?
-    regular_user?
+    admin_user?
   end
 
   def update?
-    regular_user?
+    admin_user?
   end
 
   def new?
-    regular_user?
+    admin_user?
   end
 
   def create?
-    regular_user?
+    admin_user?
   end
 
   def destroy?
-    regular_user?
+    admin_user?
   end
 end

--- a/app/views/groups/_heading_links.html.haml
+++ b/app/views/groups/_heading_links.html.haml
@@ -1,4 +1,5 @@
 %span.pull-right
   - if @group.children.count > 0
-    = link_to "View #{pluralize_with_delimiter @group.children.count, 'sub-team'}", '#teams', class: 'font-xsmall pipe-right'
-  = link_to 'Edit this team', edit_group_path(@group), { class: 'font-xsmall', data: edit_team_analytics_attributes(@group.id) }
+    = link_to "View #{pluralize_with_delimiter @group.children.count, 'sub-team'}", '#teams', class: 'font-xsmall'
+  - if policy(@group).update?
+    = link_to 'Edit this team', edit_group_path(@group), { class: 'font-xsmall pipe-left', data: edit_team_analytics_attributes(@group.id) }

--- a/app/views/groups/_people_in_team.html.haml
+++ b/app/views/groups/_people_in_team.html.haml
@@ -4,7 +4,8 @@
       People in #{ @group.short_name }
 
       %span.pull-right
-        = link_to 'Add new sub-team', new_group_group_path(@group), class: 'font-xsmall'
+        - if policy(Group).create?
+          = link_to 'Add new sub-team', new_group_group_path(@group), class: 'font-xsmall'
 
 .grid-row.mod-list.mod-list-people
   = render partial: "memberships/summary", collection: @group.distinct_non_leaderships

--- a/app/views/groups/_teams_in_team.html.haml
+++ b/app/views/groups/_teams_in_team.html.haml
@@ -9,8 +9,9 @@
 
       %span.pull-right
         - if @people_outside_subteams_count > 0
-          = link_to "View #{ pluralize_with_delimiter @people_outside_subteams_count, 'person' } not assigned to a sub-team", people_outside_subteams_group_path(@group), class: 'font-xsmall pipe-right'
-        = link_to 'Add new sub-team', new_group_group_path(@group), class: 'font-xsmall'
+          = link_to "View #{ pluralize_with_delimiter @people_outside_subteams_count, 'person' } not assigned to a sub-team", people_outside_subteams_group_path(@group), class: 'font-xsmall'
+        - if policy(Group).create?
+          = link_to 'Add new sub-team', new_group_group_path(@group), class: 'font-xsmall pipe-left'
 
 #teams.grid-row.mod-subgroups
   = render partial: "subgroup", collection: @group.children

--- a/app/views/people/_team_selector.html.haml
+++ b/app/views/people/_team_selector.html.haml
@@ -20,7 +20,7 @@
     - if @org_structure
       = render 'shared/org_browser', org_structure: @org_structure, form: membership_f, field_name: :group_id
       = link_to 'Done', '#', class: 'hide-editable-fields button-secondary'
-      - if can_edit_profiles?
+      - if policy(Group).create?
         = link_to 'Add new sub-team to the <span class="team-led"></span>'.html_safe, '#', class: 'button-add-team'
       %div.new-team
         = membership_f.label 'addteam', 'Add new sub-team to the <span class="team-led"></span>'.html_safe, class: 'form-label-bold'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,7 @@ en:
       group_deleted: "Deleted %{group}"
       create_error: "The record was not created. Please check the errors below"
       update_error: "The details were not updated. Please check the errors below"
+      unauthorised: *unauthorised
     home:
       top_level_group_needed: "To use the People Finder, first create a top-level group (without a parent)"
     information_requests:

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GroupsController, type: :controller do
   include PermittedDomainHelper
 
   before do
-    mock_logged_in_user
+    mock_logged_in_user(super_admin: true)
     Group.destroy_all
   end
 

--- a/spec/features/analytics_spec.rb
+++ b/spec/features/analytics_spec.rb
@@ -30,7 +30,7 @@ feature 'Google Analytics tracking' do
 
   context 'Edit team links' do
     before do
-      omni_auth_log_in_as 'test.user@digital.justice.gov.uk'
+      omni_auth_log_in_as_super_admin
       visit group_path(group)
     end
 

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -137,6 +137,7 @@ feature 'Group browsing' do
   end
 
   scenario 'redirecting from /groups' do
+    omni_auth_log_in_as_super_admin
     create(:group, name: 'moj')
 
     visit '/groups/moj'

--- a/spec/features/login_flow_spec.rb
+++ b/spec/features/login_flow_spec.rb
@@ -65,7 +65,7 @@ feature 'Login flow' do
 
     context 'when I have a profile' do
       scenario 'attempting a new|edit action redirects via login back to that action\'s template page with NO flash notice' do
-        create(:person, email: email)
+        create(:super_admin, email: email)
         visit new_group_path
         token_login_step_with_expectation
         expect(new_group_page).to be_displayed

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -7,6 +7,10 @@ feature "Person maintenance" do
     omni_auth_log_in_as 'test.user@digital.justice.gov.uk'
   end
 
+  before(:each, user: :super_admin) do
+    omni_auth_log_in_as_super_admin
+  end
+
   let(:edit_profile_page) { Pages::EditProfile.new }
 
   scenario 'Creating a person and making them the leader of a group', js: true do
@@ -109,7 +113,7 @@ feature "Person maintenance" do
     expect(person.memberships.last.group).to eql(Group.find_by(name: 'CSG'))
   end
 
-  scenario 'Adding a new team', js: true do
+  scenario 'Adding a new team', js: true, user: :super_admin do
     group = setup_three_level_team
     person = setup_team_member group
 

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -9,6 +9,17 @@ RSpec.describe GroupPolicy, type: :policy do
     let(:user) { build_stubbed(:person) }
 
     it { is_expected.to permit_action(:show) }
+    it { is_expected.not_to permit_action(:edit) }
+    it { is_expected.not_to permit_action(:update) }
+    it { is_expected.not_to permit_action(:new) }
+    it { is_expected.not_to permit_action(:create) }
+    it { is_expected.not_to permit_action(:destroy) }
+  end
+
+  context 'for a super admin' do
+    let(:user) { build_stubbed(:super_admin) }
+
+    it { is_expected.to permit_action(:show) }
     it { is_expected.to permit_action(:edit) }
     it { is_expected.to permit_action(:update) }
     it { is_expected.to permit_action(:new) }

--- a/spec/support/login.rb
+++ b/spec/support/login.rb
@@ -38,9 +38,12 @@ module SpecSupport
       visit token_path(token)
     end
 
+    # TODO: This method should be removed and replaced with the
+    # `omni_auth_log_in_as` method in the future, as this now encapsulates
+    # log in behaviour.
+    #
     def javascript_log_in
       visit '/'
-      click_link 'Log in'
     end
   end
 end

--- a/spec/support/login.rb
+++ b/spec/support/login.rb
@@ -26,7 +26,7 @@ module SpecSupport
         }
       )
 
-      visit 'auth/ditsso_internal'
+      visit '/auth/ditsso_internal'
     end
 
     def token_log_in_as(email)

--- a/spec/support/login.rb
+++ b/spec/support/login.rb
@@ -29,6 +29,10 @@ module SpecSupport
       visit '/auth/ditsso_internal'
     end
 
+    def omni_auth_log_in_as_super_admin
+      omni_auth_log_in_as create(:super_admin).email
+    end
+
     def token_log_in_as(email)
       token = create(:token, user_email: email)
       visit token_path(token)


### PR DESCRIPTION
This pull request changes the `GroupPolicy` to restrict creation, editing and deletion of groups to the super admin users. 

In addition, the views have been edited so that create and edit links are only displayed when a user has permission to perform the action.