### PR TITLE
Publish to Geckoboard when profiles are updated

### DIFF
--- a/app/jobs/send_notifications_job.rb
+++ b/app/jobs/send_notifications_job.rb
@@ -3,7 +3,8 @@ class SendNotificationsJob < ActiveJob::Base
   queue_as :send_notifications
 
   def perform
-    NotificationSender.new.send!
+    notify_people!
+    notify_geckoboard!
   end
 
   def max_attempts
@@ -16,6 +17,18 @@ class SendNotificationsJob < ActiveJob::Base
 
   def destroy_failed_jobs?
     false
+  end
+
+  def notify_people!
+    NotificationSender.new.send!
+  end
+
+  def notify_geckoboard!
+    GeckoboardPublisher::PhotoProfilesReport.new.publish!(true)
+    GeckoboardPublisher::ProfilesPercentageReport.new.publish!(true)
+    GeckoboardPublisher::TotalProfilesReport.new.publish!(true)
+    GeckoboardPublisher::ProfilesChangedReport.new.publish!(true)
+    GeckoboardPublisher::ProfileCompletionsReport.new.publish!(true)
   end
 
 end

--- a/app/models/concerns/geckoboard_datasets.rb
+++ b/app/models/concerns/geckoboard_datasets.rb
@@ -36,7 +36,8 @@ module Concerns::GeckoboardDatasets
     end
 
     def not_in_subteam
-      Group.find_by(ancestry_depth: 0).people_outside_subteams
+      group = Group.find_by(ancestry_depth: 0)
+      group.present? ? group.people_outside_subteams : []
     end
 
     def not_edited

--- a/spec/jobs/send_notifications_job_spec.rb
+++ b/spec/jobs/send_notifications_job_spec.rb
@@ -30,10 +30,20 @@ RSpec.describe SendNotificationsJob, type: :job do
   end
 
   context 'when performed' do
-    it 'invokes the NotificationSender' do
+    it 'invokes the NotificationSender and Geckoboard publishers' do
       mock_sender = double("NotificationSender")
+      mock_publisher = double("Publisher")
+
       expect(NotificationSender).to receive(:new).and_return(mock_sender)
       expect(mock_sender).to receive(:send!)
+
+      expect(GeckoboardPublisher::PhotoProfilesReport).to receive(:new).and_return(mock_publisher)
+      expect(GeckoboardPublisher::ProfilesPercentageReport).to receive(:new).and_return(mock_publisher)
+      expect(GeckoboardPublisher::TotalProfilesReport).to receive(:new).and_return(mock_publisher)
+      expect(GeckoboardPublisher::ProfilesChangedReport).to receive(:new).and_return(mock_publisher)
+      expect(GeckoboardPublisher::ProfileCompletionsReport).to receive(:new).and_return(mock_publisher)
+
+      expect(mock_publisher).to receive(:publish!).with(true).exactly(5).times
 
       perform_now
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,4 +75,5 @@ RSpec.configure do |config|
   config.include SpecSupport::ElasticSearchHelper
   config.include SpecSupport::FeatureFlags
   config.include SpecSupport::AppConfig
+  config.include SpecSupport::GeckoboardHelper
 end

--- a/spec/support/geckoboard_helper.rb
+++ b/spec/support/geckoboard_helper.rb
@@ -1,0 +1,15 @@
+module SpecSupport
+  module GeckoboardHelper
+    RSpec.configure do |config|
+      config.before(:each) do
+        mock_response = {
+          id: '12345',
+          fields: [],
+          unique_by: []
+        }
+
+        stub_request(:any, %r{api\.geckoboard\.com/}).to_return(status: 200, body: mock_response.to_json)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This re-introduces Geckoboard publishing of statistics on the People Finder.

The publisher tasks are now run as part of the `SendNotificationsJob`, which is triggered after a profile is updated.

This will require the correct `GECKOBOARD_API_KEY` variable to be set in the staging/prod environments on deploy. However, as this is running as a background task, it will quietly fail if the details are incorrect.