### PR TITLE
Hide suggestions

### DIFF
--- a/app/assets/stylesheets/modules/_module-media.scss
+++ b/app/assets/stylesheets/modules/_module-media.scss
@@ -238,6 +238,7 @@
   }
 
   .deletion-request-link {
-    font-size: 16px;
+    font-size: 14px;
+    padding-top: 22px;
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :can_edit_profiles?
 
+  def can_make_suggestions?
+    Rails.configuration.disable_suggestions == false
+  end
+  helper_method :can_make_suggestions?
+
   def load_user
     Login.current_user(session) || ReadonlyUser.from_request(request)
   end

--- a/app/views/people/_profile.html.haml
+++ b/app/views/people/_profile.html.haml
@@ -20,7 +20,7 @@
           - else
             - if @person.incomplete?
               = render partial: "completeness", locals: { person: @person }
-            - if can_edit_profiles?
+            - if can_make_suggestions?
               = render partial: "request_information", locals: { person: @person }
         %p.deletion-request-link
           = link_to("Has #{@person.given_name} left the department?", new_person_deletion_request_path(@person))

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,9 @@ module Peoplefinder
     # disabling the adding/editing/deletion of another person's profile
     config.disable_open_profiles = false
 
+    # disabling the ability to make suggestions to people's profiles
+    config.disable_suggestions = true
+
     config.admin_ip_ranges = ENV.fetch('ADMIN_IP_RANGES', '127.0.0.1')
 
     config.readonly_ip_whitelist = ENV.fetch('READONLY_IP_WHITELIST', '127.0.0.1')

--- a/spec/features/suggestion_spec.rb
+++ b/spec/features/suggestion_spec.rb
@@ -4,6 +4,8 @@ feature 'Make a suggestion about a profile', js: true do
   include ActiveJobHelper
   include PermittedDomainHelper
 
+  before { Rails.application.config.disable_suggestions = false }
+
   let(:me) { create(:person) }
   let(:leader) { create(:person) }
   let(:group) do


### PR DESCRIPTION
This hides the link to suggest changes to a user's profile, as we're not using suggestions for the MVP launch.

This was previously disabled, but re-enabled inadvertently when #53 re-enabled profile editing.