### PR TITLE
Include the dialling code with the phone number

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,6 +67,14 @@ module ApplicationHelper
     content_tag(:a, href: "tel:#{digits}") { telno }
   end
 
+  def phone_number_with_country_code(country, phone_number)
+    country.present? ? "+#{country.country_code} #{phone_number}" : phone_number
+  end
+
+  def call_to_with_country_code(country, phone_number)
+    call_to(phone_number_with_country_code(country, phone_number))
+  end
+
   def role_translate(subject, key, options = {})
     if subject == current_user
       subkey = 'mine'

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -199,6 +199,10 @@ class Person < ActiveRecord::Base
     [primary_phone_number, secondary_phone_number].find(&:present?)
   end
 
+  def primary_phone_country
+    primary_phone_country_code.present? ? ISO3166::Country.new(primary_phone_country_code) : nil
+  end
+
   include Concerns::ConcatenatedFields
   concatenated_field :location, :location_in_building, :building, :city, join_with: ', '
   concatenated_field :name, :given_name, :surname, join_with: ' '

--- a/app/views/people/_profile.html.haml
+++ b/app/views/people/_profile.html.haml
@@ -89,14 +89,7 @@
             %dt
               Primary phone number
             %dd
-              = call_to(@person.primary_phone_number)
-
-        - if @person.primary_phone_country_code.present?
-          %dl.inline-labels
-            %dt
-              Country dialling code
-            %dd
-              = @person.primary_phone_country_code
+              = call_to_with_country_code(@person.primary_phone_country, @person.primary_phone_number)
 
         - if @person.skype_name.present?
           %dl.inline-labels

--- a/app/views/search/_person.html.haml
+++ b/app/views/search/_person.html.haml
@@ -22,7 +22,7 @@
                   = "#{ membership.role }, " if membership.role?
                   = link_to membership.group.name, membership.group, { data: search_result_analytics_attributes(index) }
           %li.cb-person-phone
-            = call_to(person.phone)
+            = call_to_with_country_code(person.primary_phone_country, person.phone)
           %li.cb-person-email
             = mail_to(person.email, es_highlighter(hit, person, :email), data: search_result_analytics_attributes(index) )
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -93,6 +93,31 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#phone_number_with_country_code' do
+    let(:country) { ISO3166::Country.new('GB') }
+    let(:phone_number) { '1234 56789' }
+
+    it 'returns a phone number prepended with the country code given a country' do
+      expect(phone_number_with_country_code(country, phone_number)).to eq('+44 1234 56789')
+    end
+
+    it 'returns only the phone number when no country is provided' do
+      expect(phone_number_with_country_code(nil, phone_number)).to eq('1234 56789')
+    end
+  end
+
+  describe '#call_to_with_country_code' do
+    let(:country) { ISO3166::Country.new('GB') }
+    let(:phone_number) { '1234 56789' }
+
+    it 'returns a phone number prepended with the country code with a tel href' do
+      expect(self).to receive(:phone_number_with_country_code).with(country, phone_number).and_return('+44 12345')
+      expect(self).to receive(:call_to).with('+44 12345').and_return('tel:4412345')
+
+      expect(call_to_with_country_code(country, phone_number)).to eq('tel:4412345')
+    end
+  end
+
   context '#role_translate' do
     let(:current_user) { build(:person) }
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -636,4 +636,18 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe '#primary_phone_country' do
+    it 'returns an instance of ISO3166::Country when a value is present' do
+      person.primary_phone_country_code = 'GB'
+
+      expect(person.primary_phone_country).to eq(ISO3166::Country.new('GB'))
+    end
+
+    it 'returns nil when a value is not present' do
+      person.primary_phone_country_code = nil
+
+      expect(person.primary_phone_country).to be_nil
+    end
+  end
+
 end


### PR DESCRIPTION
This changes how the primary phone number is displayed to include the country dialling code.

It adds a new method to the `Person` model to return the phone country as an instance of `ISO3166::Country`, and adds helper methods to format the phone number with the dialling code.

The phone number is displayed on both the profile page and in search results, and both are updated to include the dialling code.