### PR TITLE
Merge duplicate accounts when logging in with SSO

### DIFF
--- a/app/controllers/concerns/session_person_creator.rb
+++ b/app/controllers/concerns/session_person_creator.rb
@@ -34,8 +34,15 @@ module SessionPersonCreator
     private
 
     def find_or_create_person(email, &_on_create)
-      person = Person.where(internal_auth_key: email.to_s).first_or_initialize
-      yield(person) if person.new_record?
+      person = Person.where(internal_auth_key: email.to_s).first
+      person ||= Person.where(email: email.to_s).first_or_initialize
+
+      if person.new_record?
+        yield(person)
+      elsif person.internal_auth_key != email.to_s
+        person.update_column(:internal_auth_key, email.to_s) # rubocop:disable Rails/SkipsModelValidations
+      end
+
       person
     end
 


### PR DESCRIPTION
Scenario:
- Person logs in via the SSO when they 
have an existing account (created manually or
by logging in with another provider)

- The login script tries to create a new record
but the email exists, so the page blows up.

Solution:
- If a user can’t be found with an internal_auth_key
that matches the email returned by the SSO provider,
we try to do a match on the person’s email.

- If we find a record for that person, we update their
internal_auth_key so that their account gets associated
with their most recent login mechanism

Note:
- Tests could be DRY-er, but want to be explicit 
that there *might* be a difference between an existing
account that was created manually and one created by
logging in with another provider