### PR TITLE
Remove search footer

### DIFF
--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -32,8 +32,3 @@
       - if teams_filter?
         #team-results
           = render partial: 'search/team', collection: @team_results.set
-
-.grid-row.cb-search-footer
-  .column-full
-    %br/
-    = t('.results_footer_html', new_profile_link: link_to('add them', new_person_path))

--- a/spec/features/search_filter_spec.rb
+++ b/spec/features/search_filter_spec.rb
@@ -42,11 +42,6 @@ feature 'Search results page' do
     it 'has search results' do
       is_expected.to have_search_results
     end
-
-    it 'has search footer' do
-      is_expected.to have_search_footer
-      expect(search_page.search_footer).to be_all_there
-    end
   end
 
   feature 'filtering', js: true do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -73,7 +73,6 @@ feature 'Searching feature', elastic: true do
       expect(page).to have_text('jon.browne@digital.justice.gov.uk')
       expect(page).to have_text('0711111111')
       expect(page).to have_text('Digital Prisons')
-      expect(page).to have_link('add them', href: new_person_path)
     end
   end
 

--- a/spec/support/pages/search.rb
+++ b/spec/support/pages/search.rb
@@ -9,6 +9,5 @@ module Pages
     section :search_form, Sections::SearchForm, 'form#mod-search-form'
     section :search_filters_form, Sections::SearchFiltersForm, 'form#mod-search-filter-form'
     section :search_results, Sections::SearchResults, '.cb-search-results'
-    section :search_footer, Sections::SearchFooter, '.cb-search-footer'
   end
 end


### PR DESCRIPTION
This removes the link in the search footer which currently prompts users to create a new profile.

As there is nothing else in the footer, this removes the whole footer element.