### PR TITLE
Remove ability to create person from a team page

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -147,8 +147,4 @@ class GroupsController < ApplicationController
       @versions = AuditVersionPresenter.wrap(versions)
     end
   end
-
-  def can_add_person_here?
-    can_edit_profiles? && @group && @group.ancestry_depth > 1
-  end
 end

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -32,8 +32,6 @@
     - unless @group.leaf_node?
       - if @all_people_count > 0 && @group.parent.present?
         = link_to "View #{ @all_people_count > 1 ? 'all' : '' } people", people_group_path(@group), class: 'view-all-people'
-    - if can_edit_profiles? && can_add_person_here?
-      = link_to 'Create a new profile', new_person_path, class: 'add-new-person'
 
 - unless @group.leaf_node?
   = render partial: "teams_in_team"

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -45,24 +45,6 @@ feature 'Person maintenance' do
     end
 
     context 'for a regular user', user: :regular do
-      scenario 'Creating a person from a group' do
-        team = create(:group)
-        subteam = create(:group, parent: team)
-
-        cta_text = 'Create a new profile'
-        visit group_path(department)
-        expect(page).not_to have_selector('a', text: cta_text)
-
-        click_link team.name
-        expect(page).not_to have_selector('a', text: cta_text)
-
-        click_link subteam.name
-        expect(page).to have_selector('a', text: cta_text)
-
-        click_link cta_text
-        expect(page.current_path).to eq(new_person_path)
-      end
-
       scenario 'Creating a person with a complete profile', js: true do
         create(:group, name: 'Digital')
 


### PR DESCRIPTION
This disables the link to create a person from a team page.