### PR TITLE
Ensure that the internal_auth_key is populated

### DIFF
--- a/app/controllers/concerns/session_person_creator.rb
+++ b/app/controllers/concerns/session_person_creator.rb
@@ -7,6 +7,7 @@ module SessionPersonCreator
       return unless email.permitted_domain?
       find_or_create_person(email) do |new_person|
         new_person.email = email
+        new_person.internal_auth_key = email
         new_person.given_name = auth_hash['info']['first_name']
         new_person.surname = auth_hash['info']['last_name']
       end

--- a/spec/features/omni_auth_authentication_spec.rb
+++ b/spec/features/omni_auth_authentication_spec.rb
@@ -26,6 +26,9 @@ feature 'OmniAuth Authentication' do
 
     click_link 'Sign out'
     expect(login_page).to be_displayed
+
+    # and verifying that the internal auth key has been set
+    expect(Person.last.internal_auth_key).to eq(valid_user[:info][:email].to_s)
   end
 
   scenario 'Logging in when the user has no last_name' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@ require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+ENV['SUPPORT_EMAIL'] = 'support@example.com'
 ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
- On creation from an oauth login, we need to make sure that the
internal_auth_key is populated, so that the profile record can be retrieved
by the workspace