### PR TITLE
Fixes bug: Profile not correctly setup

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,6 +155,7 @@ en:
       image_cropped: "Cropped %{person}’s image"
       update_error: "There was an error updating the image"
     person_email:
+      profile_merged: Your profiles is now correctly setup
       person_email_confirm: "You need to update your People Finder account to finish signing in"
       profile_email_updated: "Your Primary work email has been updated to %{email}"
       original_email_info_html: |

--- a/spec/controllers/person_email_controller_spec.rb
+++ b/spec/controllers/person_email_controller_spec.rb
@@ -91,6 +91,27 @@ RSpec.describe PersonEmailController, type: :controller do
     end
   end
 
+  describe 'GET edit - when there is no internal_auth_key (edge case)' do
+    let(:person) { create(:person) }
+
+    before do
+      person.update_attribute(:internal_auth_key, nil) # rubocop:disable Rails/SkipsModelValidations
+      get :edit, person_id: person.to_param, oauth_hash: oauth_hash
+    end
+
+    it 'makes sure there is an internal_auth_key' do
+      expect(assigns(:person).internal_auth_key).to eq(new_email)
+    end
+
+    it 'redirects to profile page' do
+      expect(response).to redirect_to(person_path(person))
+    end
+
+    it 'sets a relevant flash message' do
+      expect(flash[:notice]).to include('Your profiles is now correctly setup')
+    end
+  end
+
   describe 'PUT update' do
     let(:person) { create(:person, given_name: "John", surname: "Doe", email: 'john.doe@digital.justice.gov.uk') }
     let(:new_attributes) { { email: 'john.doe2@digital.justice.gov.uk', secondary_email: 'john.doe@digital.justice.gov.uk', pager_number: '0100' } }


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/DW-470

- This is an edge case. 

- If a person has been setup without an
internal_auth_key and a different email address than the
one returned from the SSO provider, the `namesakes` workflow
kicks in and they are prompted to select a profile.

- Here we effectively `merge` their SSO auth credentials
with this Person profile, and redirect to the profile
page, as opposed to inviting them to edit their email.