### PR TITLE
(fix) friendlyid slug uses an SHA1 calculated slug instead of firstna…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 # load tester file produced by rake task by default
 /spec/fixtures/csv_load_tester.csv
 /spec/support/uploads
+
+# ignore rspec examples.txt file
+examples.txt

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -72,7 +72,7 @@ class Person < ActiveRecord::Base
   friendly_id :slug_source, use: :slugged
 
   def slug_source
-    email.present? ? email.split(/@/).first : name
+    email.present? ? Digest::SHA1.hexdigest(email.split(/@/).first) : name
   end
 
   include Concerns::Searchable

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe PeopleController, type: :controller do
       context 'save button pressed' do
         it 'updates and shows the edit person page' do
           post :create, person: valid_attributes.merge(given_name: 'Francis', surname: 'Drake', email: 'francis.drake@digital.justice.gov.uk')
-          person = Person.friendly.find('francis-drake')
+          person = Person.friendly.find(Digest::SHA1.hexdigest('francis.drake'))
           expect(response).to redirect_to person_path(person)
         end
       end
@@ -346,7 +346,7 @@ RSpec.describe PeopleController, type: :controller do
         context 'pressing confirm on duplicate confirmation page' do
           it 'updates and shows the person edit page' do
             post :create, person: valid_attributes.merge(given_name: 'Francis', surname: 'Drake', email: 'francis.drake@digital.justice.gov.uk'), continue_from_duplication: '1'
-            person = Person.friendly.find('francis-drake')
+            person = Person.friendly.find(Digest::SHA1.hexdigest('francis.drake'))
             expect(response).to redirect_to person_path(person)
           end
         end

--- a/spec/features/login_flow_spec.rb
+++ b/spec/features/login_flow_spec.rb
@@ -97,7 +97,7 @@ feature 'Login flow' do
           expect(confirm_page.form).to be_all_there
           expect(confirm_page).to have_content "Create profile"
           expect(confirm_page.person_confirm_results).to have_confirmation_results count: 2
-          expect(confirm_page.person_confirm_results.name_links).to include '/people/john-doe'
+          expect(confirm_page.person_confirm_results.name_links).to include "/people/#{Digest::SHA1.hexdigest('john.doe')}"
         end
 
         scenario 'confirming I need a new profile signs me in and redirects to edit my profile' do

--- a/spec/features/person_browsing_spec.rb
+++ b/spec/features/person_browsing_spec.rb
@@ -12,7 +12,7 @@ feature 'Person browsing' do
   scenario 'visiting the my/profile path' do
     visit '/my/profile'
 
-    expect(page).to have_current_path(person_path('test-user'))
+    expect(page).to have_current_path(person_path(Digest::SHA1.hexdigest('test.user')))
   end
 
   scenario 'Using breadcrumbs on a profile page', skip: "HELP REQUIRED" do

--- a/spec/features/person_edit_notifications_spec.rb
+++ b/spec/features/person_edit_notifications_spec.rb
@@ -38,7 +38,7 @@ feature 'Person edit notifications' do
       'primary_phone_number' => [nil, ''],
       'primary_phone_country_code' => [nil, "GB"],
       'email' => [nil, 'bob.smith@digital.justice.gov.uk'],
-      'slug' => [nil, 'bob-smith']
+      'slug' => [nil, Digest::SHA1.hexdigest('bob.smith')]
     )
   end
 

--- a/spec/features/suggestion_spec.rb
+++ b/spec/features/suggestion_spec.rb
@@ -23,6 +23,7 @@ feature 'Make a suggestion about a profile', js: true do
     omni_auth_log_in_as(me.email)
     javascript_log_in
     visit person_path(subject)
+
     click_link 'Help improve this profile', match: :first
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe Person, type: :model do
     it 'generates from the first part of the email address if present' do
       person = create(:person, email: 'user.example@digital.justice.gov.uk')
       person.reload
-      expect(person.slug).to eql('user-example')
+      expect(person.slug).to eql(Digest::SHA1.hexdigest('user.example'))
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.example_status_persistence_file_path = 'examples.txt'
+
   config.profile_examples = 10
 
   config.order = :random


### PR DESCRIPTION
changed friendly id's slug from firstname.lastname to SHA1(firstname.lastname) updated a few tests too.

On deployment we need to set all slugs to nil and run Person.find_each(&:save) to update all slugs. from then on, new slugs should be created using the new convention.

An open question is what happens to existing url's pointing to /people/firstname.lastname . Per GDS we should redirect them but then there is no point in this PR's fix... :(
