### PR TITLE
Use a fixed order for imports so we are not at the whim of the filesystem.

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,13 +38,13 @@ ENV['PROFILE_API_TOKEN'] = 'DEFINED'
 Capybara.javascript_driver = :poltergeist_silent # uncomment this to disable console.log (including warn)
 Capybara.default_max_wait_time = 3
 
-Dir[File.expand_path('../../{lib,app/*}', __FILE__)].each do |path|
+Dir[File.expand_path('../../{lib,app/*}', __FILE__)].sort.each do |path|
   $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
 end
 
-Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
+Dir[File.expand_path('../support/**/*.rb', __FILE__)].sort.each { |f| require f }
 
-Dir[File.expand_path('../controllers/concerns/shared_examples*.rb', __FILE__)].each { |f| require f }
+Dir[File.expand_path('../controllers/concerns/shared_examples*.rb', __FILE__)].sort.each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 


### PR DESCRIPTION
Following the recommended fix from this article
https://makandracards.com/makandra/47551-don-t-require-files-in-random-order