### PR TITLE
Fix Carrierwave initializer configuration order

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,13 +1,13 @@
 CarrierWave.configure do |config|
   if ENV['S3_KEY'] && ENV['S3_SECRET'] && ENV['S3_BUCKET_NAME']
-    config.storage = :fog
-    config.fog_provider = 'fog/aws'
+    config.fog_provider = 'fog-aws'
     config.fog_credentials = {
       provider: 'AWS',
       aws_access_key_id: ENV['S3_KEY'],
       aws_secret_access_key: ENV['S3_SECRET'],
       region: ENV['S3_REGION']
     }
+    config.storage = :fog
     config.fog_directory = ENV['S3_BUCKET_NAME']
     config.fog_public = false
   elsif Rails.env.test?


### PR DESCRIPTION
Carrierwave requires the `config.fog_credentials` configuration
parameter to be set _before_ `config.storage`, otherwise it will fail
with a cryptic error message.