### PR TITLE
Set current Raven environment based on APPLICATION_ENV

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,11 @@
+Raven.configure do |config|
+  # c.f. https://docs.sentry.io/clients/ruby/config/
+
+  # Set environments in which Raven will send data to Sentry
+  #  (this avoids data from `development` ending up in Sentry if someone sets SENTRY_DSN locally)
+  config.environments = %w[production staging dev]
+
+  # Set environment to `APPLICATION_ENV` (normally defaults to Rails.env)
+  #   (this avoids errors from staging/dev showing up as production)
+  config.current_environment = ENV['APPLICATION_ENV'] || Rails.env
+end


### PR DESCRIPTION
Errors from People Finder currently show up in Sentry as coming from production regardless of whether they're from dev, staging, or production. This adds an initializer that sets the Raven environment based on the `APPLICATION_ENV` environment variable added in https://github.com/uktrade/ci-pipeline-config/pull/41