### PR TITLE
Remove special handling of full name searches

### DIFF
--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -24,7 +24,7 @@ class PersonSearch
   #
   def perform_search
     if query.present?
-      do_searches unless email_found || full_name_found
+      do_searches unless email_found
     end
     results
   end
@@ -34,16 +34,6 @@ class PersonSearch
   def email_found
     return false unless @email_query.include?('@')
     @matches = search_email
-    if matches.records.present?
-      @results.set = matches.records
-      @results.contains_exact_match = true
-    end
-    @results.present?
-  end
-
-  def full_name_found
-    return false if @email_query.split(' ').size != 2
-    @matches = search_full_name
     if matches.records.present?
       @results.set = matches.records
       @results.contains_exact_match = true
@@ -141,30 +131,9 @@ class PersonSearch
     }
   end
 
-  # exact match on first name AND last name
-  def full_name_search
-    {
-      bool: {
-        must: {
-          match: {
-            name: @email_query
-          }
-        }
-      }
-    }
-  end
-
   def search_email
     @search_definition = {}
     @search_definition[:query] = email_search
-    @search_definition[:highlight] = highlighter
-    @search_definition[:size] = 1
-    search @search_definition
-  end
-
-  def search_full_name
-    @search_definition = {}
-    @search_definition[:query] = full_name_search
     @search_definition[:highlight] = highlighter
     @search_definition[:size] = 1
     search @search_definition

--- a/lib/tasks/peoplefinder/db.rake
+++ b/lib/tasks/peoplefinder/db.rake
@@ -16,7 +16,7 @@ namespace :peoplefinder do
       conn = ActiveRecord::Base.connection
       tables = conn.tables
       tables.each do |table|
-        next if %w{ schema_migrations delayed_jobs sessions }.include? table
+        next if %w{ schema_migrations delayed_jobs sessions ar_internal_metadata }.include? table
         table.classify.constantize.reset_column_information
       end
     end

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe PersonSearch, elastic: true do
     @scotti = create(:person, given_name: 'John', surname: "Scotti")
     digital_services = create(:group, name: 'Digital Services')
     @bob.memberships.create(group: digital_services, role: 'Digital Director')
+    @john_duplicato1 = create(:person, given_name: 'John', surname: 'Duplicato', email: 'john.duplicato@digital.justice.gov.uk')
+    @john_duplicato2 = create(:person, given_name: 'John', surname: 'Duplicato', email: 'john.duplicato2@digital.justice.gov.uk')
 
     @john_smith = create(:person, given_name: 'John', surname: 'Smith')
     @jonathan_smith = create(:person, given_name: 'Jonathan', surname: 'Smith')
@@ -82,6 +84,12 @@ RSpec.describe PersonSearch, elastic: true do
       results = search_for('Bob Browning')
       expect(results.set.map(&:name)).to_not include(@alice.name)
       expect(results.set.map(&:name)).to include(@bob.name)
+      expect(results.contains_exact_match).to eq true
+    end
+
+    it 'copes with two people having the same name' do
+      results = search_for('John Duplicato')
+      expect(results.set.map(&:email).first(2)).to match_array [@john_duplicato1.email, @john_duplicato2.email]
       expect(results.contains_exact_match).to eq true
     end
 
@@ -228,8 +236,8 @@ RSpec.describe PersonSearch, elastic: true do
         end
 
         it 'test has expected records and ES index documents' do
-          expect(Person.count).to eql 28
-          expect(Person.search('*').results.total).to eql 28
+          expect(Person.count).to eql 30
+          expect(Person.search('*').results.total).to eql 30
         end
       end
 


### PR DESCRIPTION
People Finder handles the special case of searching for someone's full
name in a peculiar way - not only does it assume that if you are
searching for two words (no more, no less) that constitutes a full name,
it then goes and only displays *one* search result. Sounds great in
theory, but sometimes two people have the same name!

There needs to be some proper work at some point to clean up the
`PersonSearch` code and adjust the weightings, but for now this will
produce more meaningful search results.
