### PR TITLE
Fix issue with `VCAP_SERVICES` Elasticsearch

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -2,7 +2,7 @@ require 'faraday_middleware/aws_signers_v4'
 
 # TODO: Clean up once GOV.UK PaaS migration is complete
 vcap_services = JSON.parse(ENV['VCAP_SERVICES']) if ENV['VCAP_SERVICES']
-vcap_elasticsearch = vcap_services && vcap_services['elasticsearch']
+vcap_elasticsearch = vcap_services && vcap_services['elasticsearch']&.first
 
 if Rails.env.production? && vcap_elasticsearch
   Elasticsearch::Model.client = Elasticsearch::Client.new(url: vcap_elasticsearch['credentials']['uri'])


### PR DESCRIPTION
`elasticsearch` is not a hash, it's an array of hashes.