### PR TITLE
Add "Divisional security coordinator" to responsibilities

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,6 +329,7 @@ en:
       digital_champion: Digital champion
       information_manager: Information manager
       independent_panel_member: Independent panel member
+      divisional_security_coordinator: Divisional security coordinator
     profession_names:
       corp_finance: Corporate finance profession
       counter_fraud: Counter-fraud standards and profession


### PR DESCRIPTION
This is an extra field requested by the security profession.