### PR TITLE
Implement new user info header

### DIFF
--- a/app/assets/stylesheets/digital-workspace-overrides/components/_search-profile-bar.scss
+++ b/app/assets/stylesheets/digital-workspace-overrides/components/_search-profile-bar.scss
@@ -161,24 +161,20 @@
 		}
 		a {
 			position: relative;
-			padding: 18px 18px 18px 0px;
+			padding: 14px 18px 10px 0px;
 			display: inline-block;
+      line-height: 18px;
 			font-weight: 700;
 			text-decoration: none;
 			color: #FFFFFF;
-			&:before {
-				// content: '';
-				// display: block;
-				// position: absolute;
-				// top: 18px;
-				// left: -30px;
-				// background-image: asset-data-url("icon-user.png");
-				// background-repeat: no-repeat;
-
-				// width: 16px;
-				// height: 20px;
-			}
 		}
+
+    .update-account {
+      display: block;
+      font-size: 75%;
+      font-weight: 500;
+      text-decoration: underline;
+    }
 	}
 
 	//.user-account-profile-img {

--- a/app/views/layouts/peoplefinder.html.haml
+++ b/app/views/layouts/peoplefinder.html.haml
@@ -70,7 +70,7 @@
 
 - content_for :content do
   .page-content
-    = render partial: "widgets/people_search_inner_page"
+    = render partial: "widgets/people_search"
     %main#content
       = yield :breadcrumbs
       = yield

--- a/app/views/shared/_loginout.html.haml
+++ b/app/views/shared/_loginout.html.haml
@@ -1,7 +1,12 @@
-- if logged_in_regular?
-  = link_to "Hi, #{current_user.given_name}", person_path(current_user)
-  = profile_image_tag current_user, link: true
-- elsif logged_in_readonly? && !@login_screen
-  = link_to('To update People Finder, Sign in now', new_sessions_path )
-- if feature_enabled?('token_auth')
-  = link_to "Sign out", sessions_path, :method => :delete
+.user-account
+  - if logged_in_regular?
+    %a{:href => person_path(current_user)}
+      = "Hi, #{current_user.given_name}"
+      %span.update-account
+        - if current_user.completion_score < 100
+          = "Set up your profile (#{current_user.completion_score}% complete)"
+        - else
+          Edit your profile
+    = profile_image_tag current_user, link: true
+  - if feature_enabled?('token_auth')
+    = link_to "Sign out", sessions_path, :method => :delete

--- a/app/views/widgets/_people_search.html.haml
+++ b/app/views/widgets/_people_search.html.haml
@@ -2,5 +2,4 @@
 .people-search-inner-page
   .homepage-top-inner
     = render 'shared/search'
-    .user-account
-      = render "shared/loginout"
+    = render "shared/loginout"


### PR DESCRIPTION
This copies over the HAML and SCSS from Digital Workspace for the new
user info header that shows an additional line of information (profile
completeness and a more obvious link to edit)