### PR TITLE
Compatibility fixes for Elasticsearch 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ services:
   - postgresql
   - elasticsearch
 
+before_install:
+  # Override the default Travis Elasticsearch with the specific version we need
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.6.1.deb && sudo dpkg -i --force-confnew elasticsearch-6.6.1.deb && sudo service elasticsearch restart
+
 before_script:
   - psql -c 'create database peoplefinder_test;' -U postgres
   - bundle exec rake db:migrate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,17 +136,17 @@ GEM
     dotenv-rails (2.4.0)
       dotenv (= 2.4.0)
       railties (>= 3.2, < 6.0)
-    elasticsearch (5.0.4)
-      elasticsearch-api (= 5.0.4)
-      elasticsearch-transport (= 5.0.4)
-    elasticsearch-api (5.0.4)
+    elasticsearch (6.1.0)
+      elasticsearch-api (= 6.1.0)
+      elasticsearch-transport (= 6.1.0)
+    elasticsearch-api (6.1.0)
       multi_json
-    elasticsearch-model (5.0.1)
+    elasticsearch-model (6.0.0)
       activesupport (> 3)
-      elasticsearch (~> 5)
+      elasticsearch (> 1)
       hashie
-    elasticsearch-rails (5.0.1)
-    elasticsearch-transport (5.0.4)
+    elasticsearch-rails (6.0.0)
+    elasticsearch-transport (6.1.0)
       faraday
       multi_json
     equalizer (0.0.11)

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -37,8 +37,8 @@ module Concerns::Searchable
       }
     } do
       mapping do
-        indexes :name, fielddata: true, type: 'string'
-        indexes :email, index: :not_analyzed
+        indexes :name, fielddata: true, type: 'text'
+        indexes :email, type: 'keyword'
       end
     end
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - db
       - elasticsearch
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.12
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.6.0
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
- Update ES gems
- Change deprecated field types
- Use ES6 in Docker Compose