### PR TITLE
Remove old Elasticsearch initialisation logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,6 @@ gem 'whenever', require: false
 gem 'will_paginate', '~> 3.0', '>=3.0.3'
 gem 'will_paginate-bootstrap', '~> 1.0', '>= 1.0.1'
 gem 'zendesk_api'
-gem 'faraday_middleware'
-gem 'faraday_middleware-aws-signers-v4'
 
 gem 'carrierwave', '~> 1.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,11 +163,6 @@ GEM
       i18n (>= 0.7)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.12.2)
-      faraday (>= 0.7.4, < 1.0)
-    faraday_middleware-aws-signers-v4 (0.1.9)
-      aws-sdk-resources (>= 2, < 3)
-      faraday (~> 0.9)
     fastimage (2.1.0)
     ffi (1.9.25)
     fog-aws (2.0.1)
@@ -569,8 +564,6 @@ DEPENDENCIES
   elasticsearch-rails
   factory_bot_rails
   faker (~> 1.7)
-  faraday_middleware
-  faraday_middleware-aws-signers-v4
   fastimage (~> 2.1)
   fog-aws (~> 2.0.1)
   foreman

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,21 +1,6 @@
-require 'faraday_middleware/aws_signers_v4'
-
-# TODO: Clean up once GOV.UK PaaS migration is complete
-vcap_services = JSON.parse(ENV['VCAP_SERVICES']) if ENV['VCAP_SERVICES']
-vcap_elasticsearch = vcap_services && vcap_services['elasticsearch']&.first
-
-if Rails.env.production? && vcap_elasticsearch
+if Rails.env.production?
+  vcap_elasticsearch = JSON.parse(ENV['VCAP_SERVICES'])['elasticsearch'].first
   Elasticsearch::Model.client = Elasticsearch::Client.new(url: vcap_elasticsearch['credentials']['uri'])
-elsif Rails.env.production?
-  Elasticsearch::Model.client = Elasticsearch::Client.new(url: Rails.configuration.elastic_search_url) do |faraday|
-    faraday.request :aws_signers_v4,
-      credentials: Aws::Credentials.new(Rails.configuration.aws_elastic_key, Rails.configuration.aws_elastic_secret),
-      service_name: 'es',
-      region: Rails.configuration.aws_elastic_region
-
-    faraday.response :raise_error
-    faraday.adapter Faraday.default_adapter
-  end
 elsif Rails.configuration.elastic_search_url
   Elasticsearch::Model.client = Elasticsearch::Client.new(url: Rails.configuration.elastic_search_url)
 end


### PR DESCRIPTION
ES URL and credentials are now coming through `VCAP_SERVICES` on GOV.UK
PaaS, and we are no longer using AWS ES. This means we can also remove
AWS ES request signing gems as we no longer need to communicate with ES
over the internet.