### PR TITLE
Fix issue with Zendesk problem reports

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -5,7 +5,7 @@ class ReportController < ApplicationController
   def index
     client = zendesk_client
     client.tickets.create(
-      subject: "Website error submission #{Time.current}",
+      subject: "People Finder problem report (#{Time.current})",
       comment: { value: params['problem_report_problem'] },
       submitter_id: client.current_user.id,
       priority: 'normal', type: 'incident',
@@ -13,7 +13,7 @@ class ReportController < ApplicationController
       requester: { email: current_user.email, name: current_user.name }
     )
     flash[:notice] = 'Thank you for your submission. Your problem has been reported.'
-    redirect_back(fallback_location: root_path)
+    redirect_back(fallback_location: home_path)
   end
 
   def zendesk_client


### PR DESCRIPTION
These were failing because this app has no `root_path` (it's `home_path`
instead).

Also updates the Zendesk report subject to be more descriptive.