### PR TITLE
Use DIT SSO user_id to find user on login

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,8 +2,8 @@ require 'ditsso_internal'
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   if ENV['DEVELOPER_AUTH_STRATEGY']
-    provider :developer, fields: [:first_name, :last_name, :email],
-                         uid_field: :email,
+    provider :developer, fields: [:first_name, :last_name, :email, :user_id],
+                         uid_field: :user_id,
                          name: 'ditsso_internal'
   else
     provider 'ditsso_internal',

--- a/db/migrate/20190315141829_add_ditsso_user_id_to_person.rb
+++ b/db/migrate/20190315141829_add_ditsso_user_id_to_person.rb
@@ -1,0 +1,5 @@
+class AddDitssoUserIdToPerson < ActiveRecord::Migration[5.1]
+  def change
+    add_column :people, :ditsso_user_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190314145241) do
+ActiveRecord::Schema.define(version: 20190315141829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 20190314145241) do
     t.string "professions", default: [], array: true
     t.string "other_professions"
     t.text "secondary_phone_country_code"
+    t.string "ditsso_user_id"
     t.index "lower(email)", name: "index_people_on_lowercase_email", unique: true
     t.index ["slug"], name: "index_people_on_slug", unique: true
   end

--- a/lib/ditsso_internal.rb
+++ b/lib/ditsso_internal.rb
@@ -11,14 +11,15 @@ module OmniAuth
         token_url: "#{SSO_PROVIDER}/o/token/"
 
       uid do
-        raw_info['id']
+        raw_info['user_id']
       end
 
       info do
         {
           first_name: raw_info['first_name'],
           last_name: raw_info['last_name'],
-          email: raw_info['email'].downcase
+          email: raw_info['email'].downcase,
+          user_id: raw_info['user_id']
         }
       end
 

--- a/spec/controllers/concerns/shared_examples_for_session_person_creator.rb
+++ b/spec/controllers/concerns/shared_examples_for_session_person_creator.rb
@@ -9,7 +9,8 @@ shared_examples_for "session_person_creatable" do
         'first_name' => 'John',
         'last_name' => 'Doe',
         'name' => 'John Doe'
-      }
+      },
+      'uid' => 'beef'
     }
   end
 
@@ -32,6 +33,10 @@ shared_examples_for "session_person_creatable" do
       it 'has correct name' do
         expect(subject.name).to eql(expected_name)
       end
+
+      it 'has correct SSO UUID' do
+        expect(subject.ditsso_user_id).to eql(expected_user_id)
+      end
     end
   end
 
@@ -52,6 +57,10 @@ shared_examples_for "session_person_creatable" do
         expect(EmailAddress).to receive(:new).with(valid_auth_hash['info']['email']).and_return email_address
         subject
       end
+
+      it 'updates the SSO UUID' do
+        expect(subject.ditsso_user_id).to eql('beef')
+      end
     end
 
     context 'for a new person' do
@@ -60,6 +69,7 @@ shared_examples_for "session_person_creatable" do
       it_behaves_like 'new person created' do
         let(:expected_email) { 'example.user@digital.justice.gov.uk' }
         let(:expected_name) { 'John Doe' }
+        let(:expected_user_id) { 'beef' }
       end
     end
   end


### PR DESCRIPTION
This is the first step towards using DIT Staff SSO's `user_id` field
instead of the user's email as the primary way of identifying a user on
login.

- Before attempting to find a user by their SSO email on login, we check
  if a user exists with the SSO `user_id`. Only if that is unsuccessful
  do we try to find the user by email.
- On both login and user creation, store the SSO `user_id` in a new
  `ditsso_user_id` column against the People Finder user, so that all
  new users (and all those who log in after this changes is deployed)
  will have their SSO `user_id` associated with their profile.

The next step will be creating and running a task to populate all
existing users with `user_id`s from SSO. Once that is done, the
finding by email logic can be removed (and the rest of the login
code refactored).