### PR TITLE
Add rake task for importing Staff SSO User IDs

### DIFF
--- a/app/services/auth_user_loader.rb
+++ b/app/services/auth_user_loader.rb
@@ -6,10 +6,12 @@ class AuthUserLoader
     end
   end
 
-  attr_reader :auth_email
+  attr_reader :auth_email, :ditsso_user_id
 
   def initialize(email)
-    @auth_email = from_api(email)
+    api_result = from_api(email)
+    @auth_email = api_result['email']
+    @ditsso_user_id = api_result['user_id']
   end
 
   private
@@ -27,7 +29,7 @@ class AuthUserLoader
       }
     )
 
-    return nil unless response.success?
-    JSON.parse(response.body)['email']
+    return {} unless response.success?
+    JSON.parse(response.body)
   end
 end

--- a/spec/services/auth_user_loader_spec.rb
+++ b/spec/services/auth_user_loader_spec.rb
@@ -16,4 +16,20 @@ describe AuthUserLoader, auth_user_loader: true do
       it { expect(subject).to eq('auth_user@example.com') }
     end
   end
+
+  context '#ditsso_user_id' do
+    subject { described_class.new(email).ditsso_user_id }
+
+    context 'when an auth user is not found' do
+      let(:email) { 'nobody@example.com' }
+
+      it { expect(subject).to be_nil }
+    end
+
+    context 'when an auth user is found' do
+      let(:email) { 'somebody@example.com' }
+
+      it { expect(subject).to eq('deadbeef') }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,9 @@ RSpec.configure do |config|
 
     stub_request(:get, 'http://test.local/api/v1/user/introspect?email=somebody@example.com').
       with(headers: { 'Authorization'=>'Bearer abc' }).
-      to_return(status: 200, body: { email: 'auth_user@example.com' }.to_json, headers: {})
+      to_return(status: 200, body: {
+        email: 'auth_user@example.com', user_id: 'deadbeef'
+      }.to_json, headers: {})
   end
 
   config.before :each, csv_report: true do


### PR DESCRIPTION
Users logging in will now have their user ID set for them, this adds a
rake task to set the user ID for all remaining users.