### PR TITLE
Allow requesting person details in API using SSO ID

### DIFF
--- a/app/controllers/api/people_controller.rb
+++ b/app/controllers/api/people_controller.rb
@@ -13,7 +13,8 @@ module Api
     private
 
     def set_person
-      @person = Person.find_by(internal_auth_key: params[:email])
+      @person = Person.find_by(ditsso_user_id: params[:ditsso_user_id])
+      @person ||= Person.find_by(internal_auth_key: params[:email])
       return if @person
 
       auth_user_email = AuthUserLoader.find_auth_email(params[:email])

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -40,6 +40,7 @@ FactoryBot.define do
     given_name
     surname
     email
+    ditsso_user_id { 'deadbeef' }
 
     # validation requires team membership existence
     after :build do |peep, _evaluator|

--- a/spec/models/queued_notification_spec.rb
+++ b/spec/models/queued_notification_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe QueuedNotification, type: :model do
               'given_name' => [nil, 'Stephen'],
               'surname' => [nil, 'Jones'],
               'email' => [nil, 'sr@digital.justice.gov.uk'],
+              'ditsso_user_id' => [nil, 'deadbeef'],
               'internal_auth_key'=>[nil, 'sr@digital.justice.gov.uk'],
               'slug' => [nil, 'stephen-richards'],
               "membership_#{@moj.id}" => {
@@ -145,6 +146,7 @@ RSpec.describe QueuedNotification, type: :model do
               'given_name'=>[nil, 'John'],
               'surname'=>[nil, 'Jones'],
               'email'=>[nil, 'john.jones@digital.justice.gov.uk'],
+              'ditsso_user_id' => [nil, 'deadbeef'],
               'internal_auth_key'=>[nil, 'sr@digital.justice.gov.uk'],
               'slug'=>[nil, 'stephen-richards'],
               'works_friday'=>[true, false],

--- a/spec/requests/person_profile_spec.rb
+++ b/spec/requests/person_profile_spec.rb
@@ -6,57 +6,101 @@ describe 'Person Profile API', type: :request do
   let(:links_hash) { parsed_json['data']['links'] }
   let(:profile_image_url_hash_key) { 'profile-image-url' }
 
-  before do
-    get "/api/people?email=#{person.email}", headers: { authorization: "Token #{ENV['PROFILE_API_TOKEN']}" }
+  context 'by SSO user_id' do
+    before do
+      get "/api/people?ditsso_user_id=#{person.ditsso_user_id}", headers: { authorization: "Token #{ENV['PROFILE_API_TOKEN']}" }
+    end
+
+    context 'in general' do
+      let(:person) { create(:person, :with_photo, :team_member) }
+
+      it 'has the expected person attributes' do
+        expect(attr_hash).to have_key('email')
+        expect(attr_hash).to have_key('name')
+        expect(attr_hash).to have_key('completion-score')
+      end
+
+      it 'has the team' do
+        expect(attr_hash['team']).to eq(person.memberships[0].to_s)
+      end
+
+      it 'has the profile link' do
+        expect(links_hash['profile']).to eq(person_url(person))
+      end
+
+      it 'has the edit-profile link' do
+        expect(links_hash['edit-profile']).to eq(edit_person_url(person))
+      end
+
+      it 'has the profile-image-url' do
+        expect(links_hash[profile_image_url_hash_key]).to match(
+          /small_profile_photo_valid.png/
+        )
+      end
+    end
+
+    context 'with no profile image' do
+      let(:person) { create(:person) }
+
+      it 'does not have the profile-image-url' do
+        expect(links_hash[profile_image_url_hash_key]).to be_blank
+      end
+    end
   end
 
-  context 'in general' do
-    let(:person) { create(:person, :with_photo, :team_member) }
-
-    it 'has the expected person attributes' do
-      expect(attr_hash).to have_key('email')
-      expect(attr_hash).to have_key('name')
-      expect(attr_hash).to have_key('completion-score')
+  context 'by email' do
+    before do
+      get "/api/people?email=#{person.email}", headers: { authorization: "Token #{ENV['PROFILE_API_TOKEN']}" }
     end
 
-    it 'has the team' do
-      expect(attr_hash['team']).to eq(person.memberships[0].to_s)
+    context 'in general' do
+      let(:person) { create(:person, :with_photo, :team_member) }
+
+      it 'has the expected person attributes' do
+        expect(attr_hash).to have_key('email')
+        expect(attr_hash).to have_key('name')
+        expect(attr_hash).to have_key('completion-score')
+      end
+
+      it 'has the team' do
+        expect(attr_hash['team']).to eq(person.memberships[0].to_s)
+      end
+
+      it 'has the profile link' do
+        expect(links_hash['profile']).to eq(person_url(person))
+      end
+
+      it 'has the edit-profile link' do
+        expect(links_hash['edit-profile']).to eq(edit_person_url(person))
+      end
+
+      it 'has the profile-image-url' do
+        expect(links_hash[profile_image_url_hash_key]).to match(
+          /small_profile_photo_valid.png/
+        )
+      end
     end
 
-    it 'has the profile link' do
-      expect(links_hash['profile']).to eq(person_url(person))
+    context 'with no profile image' do
+      let(:person) { create(:person) }
+
+      it 'does not have the profile-image-url' do
+        expect(links_hash[profile_image_url_hash_key]).to be_blank
+      end
     end
 
-    it 'has the edit-profile link' do
-      expect(links_hash['edit-profile']).to eq(edit_person_url(person))
+    context 'when the person is found by the AuthUserLoader', auth_user_loader: true do
+      let(:person) { create(:person, internal_auth_key: 'auth_user@example.com') }
+
+      it { expect(attr_hash['email']).to eq(person.email) }
     end
 
-    it 'has the profile-image-url' do
-      expect(links_hash[profile_image_url_hash_key]).to match(
-        /small_profile_photo_valid.png/
-      )
-    end
-  end
+    context 'when the person is not found by the AuthUserLoader', auth_user_loader: true do
+      let(:person) { double(:person, email: 'nobody@example.com') }
 
-  context 'with no profile image' do
-    let(:person) { create(:person) }
-
-    it 'does not have the profile-image-url' do
-      expect(links_hash[profile_image_url_hash_key]).to be_blank
-    end
-  end
-
-  context 'when the person is found by the AuthUserLoader', auth_user_loader: true do
-    let(:person) { create(:person, internal_auth_key: 'auth_user@example.com') }
-
-    it { expect(attr_hash['email']).to eq(person.email) }
-  end
-
-  context 'when the person is not found by the AuthUserLoader', auth_user_loader: true do
-    let(:person) { double(:person, email: 'nobody@example.com') }
-
-    it 'returns a 404' do
-      expect(response.status).to eq(404)
+      it 'returns a 404' do
+        expect(response.status).to eq(404)
+      end
     end
   end
 end


### PR DESCRIPTION
Currently these are requested by email (`internal_auth_key`), but we are
moving away from that in both applications and should only be using the
SSO `user_id` from now on.