### PR TITLE
Make SSO UUID mandatory on people

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -133,6 +133,7 @@ class Person < ApplicationRecord
     end
   end
 
+  validates :ditsso_user_id, presence: true
   validates :given_name, presence: true
   attr_accessor :skip_must_have_surname
   validates :surname, presence: true, unless: :skip_must_have_surname

--- a/app/services/random_generator.rb
+++ b/app/services/random_generator.rb
@@ -60,6 +60,7 @@ class RandomGenerator
     surname = Faker::Name.last_name
 
     {
+      ditsso_user_id: SecureRandom.uuid,
       given_name: given_name,
       surname: surname,
       email: "#{given_name}.#{surname}@#{@domain}",

--- a/spec/features/omni_auth_authentication_spec.rb
+++ b/spec/features/omni_auth_authentication_spec.rb
@@ -17,8 +17,8 @@ feature 'OmniAuth Authentication' do
 
     visit '/'
 
-    # and verifying that the internal auth key has been set
-    expect(Person.last.internal_auth_key).to eq(valid_user[:info][:email].to_s)
+    # and verifying that the SSO user ID
+    expect(Person.last.ditsso_user_id).to eq(valid_user[:uid].to_s)
   end
 
   scenario 'Logging in when the user has no last_name' do
@@ -28,26 +28,6 @@ feature 'OmniAuth Authentication' do
     expect(page).to have_text('Hi, John')
   end
 
-  scenario 'Logging in when the user has an existing account from another provider' do
-    person = create(:person, given_name: 'Alice', email: valid_user[:info][:email])
-    person.update_column(:internal_auth_key, 'alice@example.com') # rubocop:disable Rails/SkipsModelValidations
-    OmniAuth.config.mock_auth[:ditsso_internal] = valid_user
-
-    visit '/'
-    expect(page).to have_text('Hi, Alice')
-    expect(person.reload.internal_auth_key).to eq(valid_user[:info][:email].to_s)
-  end
-
-  scenario 'Logging in when the user has an account that was created by another person' do
-    person = create(:person, given_name: 'Alice', email: valid_user[:info][:email])
-    person.update_column(:internal_auth_key, nil) # rubocop:disable Rails/SkipsModelValidations
-    OmniAuth.config.mock_auth[:ditsso_internal] = valid_user
-
-    visit '/'
-    expect(page).to have_text('Hi, Alice')
-    expect(person.reload.internal_auth_key).to eq(valid_user[:info][:email].to_s)
-  end
-
   scenario 'Non existent users are redirected to their new profiles edit page after logging in' do
     OmniAuth.config.mock_auth[:ditsso_internal] = valid_user
     visit group_path(group)
@@ -55,7 +35,7 @@ feature 'OmniAuth Authentication' do
   end
 
   scenario 'Existing users are redirected to their desired path after logging in' do
-    create(:person, email: valid_user[:info][:email])
+    create(:person, ditsso_user_id: 'beef')
     OmniAuth.config.mock_auth[:ditsso_internal] = valid_user
     visit group_path(group)
     expect(group_page).to be_displayed
@@ -65,7 +45,9 @@ end
 def valid_user
   OmniAuth::AuthHash.new(
     provider: 'ditsso_internal',
+    uid: 'beef',
     info: {
+      user_id: 'beef',
       email: 'test.user@digital.justice.gov.uk',
       first_name: 'john',
       last_name: 'doe'
@@ -76,7 +58,9 @@ end
 def valid_user_no_last_name
   OmniAuth::AuthHash.new(
     provider: 'ditsso_internal',
+    uid: 'bad',
     info: {
+      user_id: 'bad',
       email: 'test.user@digital.justice.gov.uk',
       first_name: 'John',
       last_name: ''


### PR DESCRIPTION
Every person created from this point on should have a Staff SSO user ID.
This adds a validation to ensure we don't reach an invalid state.