### PR TITLE
Add uniqueness validation for SSO user ID

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -133,7 +133,7 @@ class Person < ApplicationRecord
     end
   end
 
-  validates :ditsso_user_id, presence: true
+  validates :ditsso_user_id, presence: true, uniqueness: true
   validates :given_name, presence: true
   attr_accessor :skip_must_have_surname
   validates :surname, presence: true, unless: :skip_must_have_surname

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe Person, type: :model do
   let(:person) { build(:person) }
   it { should validate_presence_of(:given_name).on(:update) }
   it { should validate_presence_of(:surname) }
+  it { should validate_presence_of(:ditsso_user_id) }
+  it { should validate_uniqueness_of(:ditsso_user_id) }
   it { should validate_presence_of(:email) }
   it { should validate_uniqueness_of(:email).case_insensitive }
   it { should have_many(:groups) }


### PR DESCRIPTION
This should never be an issue during normal operation, but can sometimes
occur during manual data munging - this ensures that SSO user IDs are
always unique.