### PR TITLE
Ensure session creation doesn't fail silently

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,8 +10,6 @@ class SessionsController < ApplicationController
       create_and_login_person(@person)
     elsif @person
       login_person(@person)
-    else
-      render :failed
     end
   end
 
@@ -48,11 +46,6 @@ class SessionsController < ApplicationController
   def create_and_login_person(person)
     person.skip_must_have_surname = true
     person.skip_must_have_team = true
-
-    unless person.valid?
-      render :failed
-      return
-    end
 
     PersonCreator.new(
       person: person,


### PR DESCRIPTION
There was an issue with a user whose record refused to save, and rather
than blowing up and notifying us about it, the save just silently
failed.

There is no longer a reason for rescuing a failed save - let it fail
and then we can deal with it.