### PR TITLE
Remove requirement for unique email addresses

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -139,7 +139,7 @@ class Person < ApplicationRecord
   validates :given_name, presence: true
   attr_accessor :skip_must_have_surname
   validates :surname, presence: true, unless: :skip_must_have_surname
-  validates :email, presence: true, uniqueness: { case_sensitive: false }, email: true
+  validates :email, presence: true, email: true
   validates :secondary_email, email: true, allow_blank: true
 
   has_many :memberships, -> { includes(:group).order('groups.name') }, dependent: :destroy

--- a/db/migrate/20190508161402_remove_uniqueness_key_on_people_email.rb
+++ b/db/migrate/20190508161402_remove_uniqueness_key_on_people_email.rb
@@ -1,0 +1,5 @@
+class RemoveUniquenessKeyOnPeopleEmail < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :people, name: 'index_people_on_lowercase_email'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190315141829) do
+ActiveRecord::Schema.define(version: 20190508161402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,7 +107,6 @@ ActiveRecord::Schema.define(version: 20190315141829) do
     t.string "other_professions"
     t.text "secondary_phone_country_code"
     t.string "ditsso_user_id"
-    t.index "lower(email)", name: "index_people_on_lowercase_email", unique: true
     t.index ["slug"], name: "index_people_on_slug", unique: true
   end
 

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -119,15 +119,6 @@ describe 'Person maintenance' do
         expect(edit_profile_page.error_summary.leader_unique_error).to have_text "#{role} (leader of #{department}) already exists. Select \"No\" or change the current #{role}'s profile first", count: 1
       end
 
-      it 'Editing a person to have an existing e-mail raises an error' do
-        existing_person = create(:person)
-
-        edit_profile_page.load(slug: person.slug)
-        edit_profile_page.form.email.set existing_person.email
-        edit_profile_page.form.save.click
-        expect(edit_profile_page.error_summary).to have_email_error
-      end
-
       it 'Recording audit details' do
         allow_any_instance_of(ActionDispatch::Request)
           .to receive(:remote_ip).and_return('1.2.3.4')

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe Person, type: :model do
   it { is_expected.to validate_presence_of(:ditsso_user_id) }
   it { is_expected.to validate_uniqueness_of(:ditsso_user_id) }
   it { is_expected.to validate_presence_of(:email) }
-  it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
   it { is_expected.to have_many(:groups) }
 
   it { is_expected.to respond_to(:pager_number) }


### PR DESCRIPTION
Since emails are no longer used for identification purposes, and we have
situations where two people would want to use the same email address
(e.g. job shares), this removes the requirement for email addresses to
be unique both in the app and the database.