### PR TITLE
Fix white "GOV.UK" text obscuring header logo

### DIFF
--- a/app/assets/stylesheets/digital-workspace-overrides/components/_global-header.scss
+++ b/app/assets/stylesheets/digital-workspace-overrides/components/_global-header.scss
@@ -169,6 +169,7 @@
 		background-image: asset-data-url("dit-logo_000@2x.png");
 		background-size: 137px 65px;
 		margin-top: 15px;
+		font-size: 0px;
 
 		width: 137px;
 		height: 65px;

--- a/app/views/layouts/peoplefinder.html.haml
+++ b/app/views/layouts/peoplefinder.html.haml
@@ -7,11 +7,13 @@
 - content_for :homepage_url do
   = ENV['HOME_PAGE_URL']
 
+- content_for :global_header_text do
+  = 'Department for International Trade'
+
 - content_for :logo_link_title do
   = 'Go to the Digital Workspace homepage'
 
 - content_for :head do
-
   = stylesheet_link_tag "application", media: "all"
   = stylesheet_link_tag "digital-workspace-overrides/application", media: "all"
   = csrf_meta_tag


### PR DESCRIPTION
The DIT logo in the header started being overlayed with a "GOV.UK" text
after a recent GOV.UK Frontend update. This adds the 0px font size that
is being used in the Digital Workspace frontend code to harmonise the
two apps and remove the text from users' view.