### PR TITLE
Allow super admins to set SSO user ID

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -97,7 +97,7 @@ class PeopleController < ApplicationController
     # Parameters that can only be updated by super admins, not regular users
     return [] unless super_admin?
 
-    [:super_admin]
+    %i[super_admin ditsso_user_id]
   end
 
   def set_org_structure

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -150,6 +150,8 @@
     .form-group
       %h3.heading-medium.with-border-lg Administrative options
 
+      = f.text_field :ditsso_user_id
+
       %fieldset#admin-options
         %p
           %span.form-hint

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 CarrierWave.configure do |config|
-  if ENV['S3_KEY'] && ENV['S3_SECRET'] && ENV['S3_BUCKET_NAME']
+  if ENV['S3_KEY'].present? && ENV['S3_SECRET'].present? && ENV['S3_BUCKET_NAME'].present?
     config.fog_provider = 'fog-aws'
     config.fog_credentials = {
       provider: 'AWS',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,6 +510,7 @@ en:
         other_overseas: Other - Overseas
         other_additional_responsibilities: Other additional roles and responsibilities
         super_admin: Allow this person to administrate People Finder
+        ditsso_user_id: Staff SSO user ID
       membership:
         role: "Job title"
         group: Team
@@ -548,6 +549,7 @@ en:
         language_fluent: Add languages at which you are fluent. Use a comma to separate languages.
         language_intermediate: Add languages at which you have intermediate fluency. Use a comma to separate languages.
         previous_positions: Please note your previous experience
+        ditsso_user_id: The "Unique User ID" for this user in the Staff Single Sign On system
       membership:
         role: Role within this team
       group:

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -160,34 +160,28 @@ RSpec.describe PeopleController, type: :controller do
       end
     end
 
-    describe 'when trying to grant super admin privileges' do
+    describe 'when trying to change super-admin only parameters' do
+      let(:attributes_with_super_admin) do
+        attributes_for(:super_admin).merge(ditsso_user_id: 'new_id')
+      end
+
+      before do
+        put :update, params: { id: person.to_param, person: attributes_with_super_admin }
+      end
+
       context 'if the current user is not a super admin themselves' do
-        let(:attributes_with_super_admin) do
-          attributes_for(:super_admin)
-        end
-
-        before do
-          put :update, params: { id: person.to_param, person: attributes_with_super_admin }
-        end
-
         it 'does not grant super admin privileges' do
           person.reload
           expect(person).not_to be_super_admin
+          expect(person.ditsso_user_id).not_to eq('new_id')
         end
       end
 
       context 'if the current user IS a super user', user: :super_admin do
-        let(:attributes_with_super_admin) do
-          attributes_for(:super_admin)
-        end
-
-        before do
-          put :update, params: { id: person.to_param, person: attributes_with_super_admin }
-        end
-
         it 'grants super admin privileges' do
           person.reload
           expect(person).to be_super_admin
+          expect(person.ditsso_user_id).to eq('new_id')
         end
       end
     end


### PR DESCRIPTION
This can be used to correct issues with users being deleted from SSO and
recreated (with a new ID), leading to their People Finder profiles becoming
detached from their SSO identity.

- Add field in administrative section to update `ditsso_user_id`
- Fix configuration failure with blank values in env file