### PR TITLE
Add team structure export to management area

### DIFF
--- a/app/controllers/admin/team_extracts_controller.rb
+++ b/app/controllers/admin/team_extracts_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Admin
+  class TeamExtractsController < ApplicationController
+    include ApplicationHelper
+
+    require 'csv'
+    before_action :authorize_user
+
+    def show
+      respond_to do |format|
+        format.csv do
+          send_data groups_csv, filename: "teams-#{Time.zone.today}.csv"
+        end
+      end
+    end
+
+    private
+
+    def groups_csv
+      @groups = Group.order(:id)
+
+      CSV.generate(headers: true) do |csv|
+        csv << team_headers
+        @groups.each do |group|
+          csv << group_row(group)
+        end
+      end
+    end
+
+    def team_headers
+      %w[
+        TeamId TeamName ParentId Ancestry
+      ]
+    end
+
+    def group_row(group)
+      [
+        group.id,
+        group.name,
+        group.parent_id,
+        group.ancestry
+      ]
+    end
+
+    def authorize_user
+      authorize 'Admin::Management'.to_sym, :csv_extract_report?
+    end
+  end
+end

--- a/app/views/admin/management/show.html.haml
+++ b/app/views/admin/management/show.html.haml
@@ -10,10 +10,12 @@
       = t('management.report_header')
 
     %h3.heading-small
-      = "CSV extract: Profiles"
+      = "CSV extracts"
     #csv-extract
       %span.download-link
-        = link_to 'download', admin_profile_extract_path(format: :csv), class: "button"
+        = link_to 'Profiles', admin_profile_extract_path(format: :csv), class: "button"
+      %span.download-link
+        = link_to 'Teams', admin_team_extract_path(format: :csv), class: "button"
 
     %h3.heading-small
       = "User behaviour report"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
     get 'user_behavior_report', controller: 'management', action: :user_behavior_report
     get 'generate_user_behavior_report', controller: 'management', action: :generate_user_behavior_report
     resource :profile_extract, only: [:show]
+    resource :team_extract, only: [:show]
   end
 
   get '/my/profile', to: 'home#my_profile'

--- a/spec/features/csv_extract_spec.rb
+++ b/spec/features/csv_extract_spec.rb
@@ -9,8 +9,8 @@ describe 'Super admin views CSV extracts' do
     click_link 'Manage'
   end
 
-  it 'in general' do
-    within('#csv-extract') { click_link 'download' }
+  it 'download of profiles' do
+    within('#csv-extract') { click_link 'Profiles' }
 
     header = page.response_headers['Content-Disposition']
     expect(header).to match(/^attachment/)
@@ -21,5 +21,19 @@ describe 'Super admin views CSV extracts' do
     person = Person.last
     person_fields = "#{person.given_name},#{person.surname},#{person.email}"
     expect(page).to have_text(person_fields)
+  end
+
+  it 'download of teams' do
+    within('#csv-extract') { click_link 'Teams' }
+
+    header = page.response_headers['Content-Disposition']
+    expect(header).to match(/^attachment/)
+    expect(header).to match(/filename="teams-.*.csv"$/)
+
+    expect(page).to have_text('TeamId,TeamName,ParentId,Ancestry')
+
+    group = Group.last
+    group_fields = "#{group.id},#{group.name},#{group.parent_id},#{group.ancestry}"
+    expect(page).to have_text(group_fields)
   end
 end


### PR DESCRIPTION
We need to be able to run reports that correlate people to teams, and this
allows us to generate a list of teams and their structure in the same way
that we can export lists of profiles.