### PR TITLE
Remove legacy profile image upload functionality

### DIFF
--- a/app/models/concerns/geckoboard_datasets.rb
+++ b/app/models/concerns/geckoboard_datasets.rb
@@ -10,7 +10,6 @@ module Concerns::GeckoboardDatasets
         .count
     end
 
-    # NOTE does not include legacy photos
     def photo_profiles_by_day_added
       unscoped
         .where.not(profile_photo: nil)
@@ -22,7 +21,7 @@ module Concerns::GeckoboardDatasets
 
     def photo_profiles
       unscope(:order)
-        .where('profile_photo_id IS NOT NULL OR length(image) > 0')
+        .where('profile_photo_id IS NOT NULL')
     end
 
     def additional_info_profiles

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -16,7 +16,7 @@ class ImageUploader < CarrierWave::Uploader::Base
       '%suploads/peoplefinder/%s/%s/%s',
       base_upload_dir,
       model.class.to_s.underscore,
-      mounted_as_without_legacy_prefix,
+      mounted_as,
       model.id
     )
   end
@@ -65,10 +65,6 @@ class ImageUploader < CarrierWave::Uploader::Base
     w = model.crop_w.to_i
     h = model.crop_h.to_i
     [x, y, w, h]
-  end
-
-  def mounted_as_without_legacy_prefix
-    mounted_as.to_s.sub(/^legacy_/, '')
   end
 
   # white list of permissable file extensions for upload

--- a/db/migrate/20190916141532_remove_legacy_profile_image_from_people.rb
+++ b/db/migrate/20190916141532_remove_legacy_profile_image_from_people.rb
@@ -1,0 +1,5 @@
+class RemoveLegacyProfileImageFromPeople < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :people, :image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190716104801) do
+ActiveRecord::Schema.define(version: 20190916141532) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,7 +72,6 @@ ActiveRecord::Schema.define(version: 20190716104801) do
     t.boolean "works_wednesday", default: true
     t.boolean "works_thursday", default: true
     t.boolean "works_friday", default: true
-    t.string "image"
     t.string "slug"
     t.boolean "works_saturday", default: false
     t.boolean "works_sunday", default: false

--- a/lib/s3/bucket.rb
+++ b/lib/s3/bucket.rb
@@ -9,7 +9,7 @@ module S3
   # bucket.
   #
   class Bucket
-    # needs to be a key-part that exists in both legacy and current profile image keys/file-paths
+    # needs to be a key-part that exists in current profile image keys/file-paths
     PROFILE_IMAGE_KEY_MATCHER = '/image/'
 
     def initialize(name = nil, options = {})

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -60,24 +60,6 @@ RSpec.describe Concerns::Completion do
         expect(person).not_to be_incomplete
       end
     end
-
-    context 'when legacy image field exists instead of profile photo and all other fields completed' do
-      let(:person) do
-        create(
-          :person,
-          completed_attributes
-            .reject { |k, _v| k == :profile_photo_id }
-            .merge(image: 'profile_MoJ_small.jpg')
-        )
-      end
-
-      before { create(:membership, person: person) }
-
-      it 'returns 100' do
-        expect(person.completion_score).to be(100)
-        expect(person).not_to be_incomplete
-      end
-    end
   end
 
   context '.overall_completion' do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -613,16 +613,8 @@ RSpec.describe Person, type: :model do
       end
     end
 
-    context 'when there is a legacy image but no profile photo' do
-      it 'returns the mounted uploader' do
-        person.assign_attributes image: 'cats.gif'
-        expect(person.profile_image).to be_kind_of(ImageUploader)
-      end
-    end
-
     context 'when there is no image' do
       it 'returns nil' do
-        person.assign_attributes image: nil
         expect(person.profile_image).to be_nil
       end
     end

--- a/spec/uploaders/image_uploader_spec.rb
+++ b/spec/uploaders/image_uploader_spec.rb
@@ -53,20 +53,8 @@ RSpec.describe ImageUploader, type: :uploader do
     end
 
     it 'has a consistent path' do
-      # If you change this, you must also consider what to do with legacy image uploads.
       expect(subject.store_dir)
         .to eq("#{Rails.root}/spec/support/uploads/peoplefinder/profile_photo/image/#{profile_photo.id}")
-    end
-  end
-
-  context 'with a person object' do
-    subject { person.legacy_image }
-
-    let(:person) { create(:person, image: sample_image) }
-
-    it 'has a consistent path' do
-      expect(subject.store_dir)
-        .to eq("#{Rails.root}/spec/support/uploads/peoplefinder/person/image/#{person.id}")
     end
   end
 end


### PR DESCRIPTION
Long before being launched at DIT, People Finder changed how it handled
uploaded profile images (from an `image` column to a `ProfilePhoto`
model). Rather than migrating all users to the new profile images, the
code was modified to allow picking up either of the two storage
locations.

This removes all references to the legacy image storage as this was
never used at DIT.