### PR TITLE
Remove Govspeak from app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'haml-rails'
 gem 'jbuilder'
 gem 'jquery-rails'
 gem 'json'
+gem 'kramdown'
 gem 'mail'
 gem 'mini_magick'
 gem 'omniauth-oauth2'
@@ -53,12 +54,6 @@ gem 'carrierwave', '~> 1.3.1'
 #       in People Finder. Once the frontend code has been cleaned up, we can
 #       start looking into this.
 gem 'sprockets', '~> 3'
-
-# TODO: Pinned because >= 6.0 includes extreme amounts of unneeded dependencies
-#       All this just for a tiny bit of Markdown in team descriptions, we
-#       should find something more lightweight (or just use Trix once we're on
-#       a more up-to-date Rails)
-gem 'govspeak', '~> 5.0'
 
 group :assets do
   gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,8 +111,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commander (4.4.7)
-      highline (~> 2.0.0)
     concurrent-ruby (1.1.5)
     countries (3.0.0)
       i18n_data (~> 0.8.0)
@@ -192,17 +190,6 @@ GEM
     geckoboard-ruby (0.4.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govspeak (5.9.1)
-      actionview (~> 5.0)
-      addressable (>= 2.3.8, < 3)
-      commander (~> 4.4)
-      htmlentities (~> 4)
-      i18n (~> 0.7)
-      kramdown (~> 1.15.0)
-      money (~> 6.7)
-      nokogiri (~> 1.5)
-      rinku (~> 2.0)
-      sanitize (~> 4.6)
     govuk_elements_form_builder (0.1.1)
       rails (>= 4.2)
     govuk_elements_rails (2.2.1)
@@ -225,7 +212,6 @@ GEM
       railties (>= 5.1)
     hashdiff (1.0.0)
     hashie (3.6.0)
-    highline (2.0.3)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -277,16 +263,12 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
-    money (6.13.4)
-      i18n (>= 0.6.4, <= 2)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
-    nokogumbo (1.5.0)
-      nokogiri
     oauth2 (1.4.2)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
@@ -373,7 +355,6 @@ GEM
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
-    rinku (2.0.6)
     rspec-core (3.9.0)
       rspec-support (~> 3.9.0)
     rspec-expectations (3.9.0)
@@ -408,10 +389,6 @@ GEM
       sexp_processor (~> 4.9)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
-    sanitize (4.6.6)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.4.4)
-      nokogumbo (~> 1.4)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -528,7 +505,6 @@ DEPENDENCIES
   fog-aws
   friendly_id
   geckoboard-ruby
-  govspeak (~> 5.0)
   govuk_elements_form_builder (~> 0.0)
   govuk_elements_rails (~> 2.2)
   govuk_frontend_toolkit
@@ -538,6 +514,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   json
+  kramdown
   logstasher
   mail
   mini_magick

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,18 +18,18 @@ module ApplicationHelper
     "#{updated_at(@last_updated_at)}#{updated_by(current_object)}." if current_object && @last_updated_at.present?
   end
 
-  def govspeak(source)
+  def markdown(source)
     options = { header_offset: 2 }
-    doc = Govspeak::Document.new(source, options)
-    doc.to_sanitized_html.html_safe
+    doc = Kramdown::Document.new(source, options)
+    sanitize(doc.to_html, tags: %w[h1 h2 h3 h4 h5 ul li a], attributes: %w[href])
   end
 
-  def govspeak_without_hyperlinks(source)
-    # HACK: In the team description list, we render markdown into an <a> tag,
-    #   so we don't want any more <a> tags because it would be pointless and
-    #   be invalid HTML (but we want to preserve the remaining markup).
-    #   Govspeak doesn't let us do that easily.
-    govspeak(source).gsub(%r{<a[^>]*>(.*?)</a>}, '\1').html_safe
+  def markdown_without_hyperlinks(source)
+    # In the team description list, we render markdown into an <a> tag,
+    # so we don't want any more <a> tags because it would be pointless and
+    # be invalid HTML (but we want to preserve the remaining markup).
+    original = markdown(source)
+    sanitize(original, tags: %w[h1 h2 h3 h4 h5 ul li])
   end
 
   FLASH_NOTICE_KEYS = %w[error notice warning].freeze

--- a/app/views/groups/_subgroup.html.haml
+++ b/app/views/groups/_subgroup.html.haml
@@ -9,4 +9,4 @@
           of profile information completed
       %div.about-subgroup
         .formatted-text
-          = govspeak_without_hyperlinks(truncate(subgroup.with_placeholder_default(:description), length: 350))
+          = markdown_without_hyperlinks(truncate(subgroup.with_placeholder_default(:description), length: 350))

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -24,7 +24,7 @@
       = "About the team"
 
     .mod-wrap-text.formatted-text
-      = govspeak(@group.with_placeholder_default(:description))
+      = markdown(@group.with_placeholder_default(:description))
 
     - unless @group.leaf_node?
       - if @all_people_count > 0 && @group.parent.present?

--- a/app/views/pages/show.html.haml
+++ b/app/views/pages/show.html.haml
@@ -8,4 +8,4 @@
 
 .grid-row.formatted-text
   .column-full
-    = govspeak(t(:body, scope: [:pages, @page_name]))
+    = markdown(t(:body, scope: [:pages, @page_name]))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -43,19 +43,19 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#govspeak' do
+  describe '#markdown' do
     it 'renders Markdown starting from h3' do
       source = "# Header\n\nPara para"
-      fragment = Capybara::Node::Simple.new(govspeak(source))
+      fragment = Capybara::Node::Simple.new(markdown(source))
 
       expect(fragment).to have_selector('h3', text: 'Header')
     end
   end
 
-  describe '#govspeak_without_hyperlinks' do
+  describe '#markdown_without_hyperlinks' do
     it 'renders Markdown with <a> tags replaced by their content' do
       source = "# Header\n\nPara para\n\n[link to](nowhere)"
-      fragment = Capybara::Node::Simple.new(govspeak_without_hyperlinks(source))
+      fragment = Capybara::Node::Simple.new(markdown_without_hyperlinks(source))
 
       expect(fragment).to have_selector('h3', text: 'Header')
       expect(fragment).not_to have_selector('a')


### PR DESCRIPTION
We use the `govspeak` library to parse Markdown in People Finder - this
is complete overkill for what is a tiny subset of Markdown being used,
especially since the latest version of the library substantially
increases the number of dependencies required to the point of basically
including half of GOV.UK.

This replaces it with `kramdown`, which is much smaller and does the
same thing, and cleans up the Markdown-related code in the process.