### PR TITLE
Add proof-of-concept search API

### DIFF
--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  class SearchController < Api::ApplicationController
+    include SearchHelper
+
+    def index
+      @teams = GroupSearch.new(query, SearchResults.new).perform_search
+      @people = PersonSearch.new(query, SearchResults.new).perform_search
+
+      render json: { teams: @teams.set, people: @people.set }
+    end
+
+    private
+
+    def query
+      params[:query]
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   namespace :api, format: [:json] do
     resource :people, only: [:show]
+    match '/search', to: 'search#index', via: [:get]
   end
 
   resources :profile_photos, only: [:create]


### PR DESCRIPTION
Adds a trivial API endpoint returning search results, to be used in an
experimental search service.