### PR TITLE
Implement UX review "quick win" recommendations

### DIFF
--- a/app/assets/stylesheets/digital-workspace-overrides/components/_edit-profile.scss
+++ b/app/assets/stylesheets/digital-workspace-overrides/components/_edit-profile.scss
@@ -35,7 +35,7 @@ ul.inline-list {
 	border: 2px solid $brand_color_a;
 	.team {
 		a {
-			color: $brand_color_a;
+			color: $govuk-link-color;
 		}
 		h3 {
 			background-color: #fdf6f3;

--- a/app/assets/stylesheets/digital-workspace-overrides/components/_search-profile-bar.scss
+++ b/app/assets/stylesheets/digital-workspace-overrides/components/_search-profile-bar.scss
@@ -16,10 +16,7 @@
 			color: #ffffff;
 			overflow: auto;
 			.profile-flair {
-				background: $brand_color_c; /* For unsupported browsers */
-				background: rgba($brand_color_c, 0.3); /* IE8 */
-				-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=$brand_color_c, endColorstr=$brand_color_c)"; /* IE8 */
-				filter: alpha(opacity=30); /* IE8 */
+				background: #333333;
 				zoom: 1; /* IE8 */
 				display: block;
 				height: 70px;
@@ -149,9 +146,7 @@
 	.user-account {
 		width: 31%;
 		float: right;
-		background: $brand_color_c;
-		background: rgba(205,22,50,0.3);
-		-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=$brand_color_c, endColorstr=$brand_color_c)";
+		background: #333333;
 		text-align: right;
 		.maginot {
 			a {

--- a/app/assets/stylesheets/digital-workspace-overrides/util/_links.scss
+++ b/app/assets/stylesheets/digital-workspace-overrides/util/_links.scss
@@ -4,21 +4,20 @@ a {
 	cursor: pointer;
 
 	&:link {
-		color: $brand_color_a;
+		color: $govuk-link-color;
 		text-decoration: underline;
 	}
 
 	&:hover {
-		color: $brand_color_a;
-		text-decoration: none;
+		color: $govuk-link-color;
 	}
 
 	&:active {
-		color: $brand_color_a;
+		color: $govuk-link-color;
 	}
 
 	&:visited {
-		color: $brand_color_b;
+		color: $govuk-link-visited-color;
 	}
 
 	// Heading links

--- a/app/assets/stylesheets/digital-workspace-overrides/util/_pf-specific-overrides.scss
+++ b/app/assets/stylesheets/digital-workspace-overrides/util/_pf-specific-overrides.scss
@@ -15,22 +15,22 @@
 			&.subgroup-link-block {
 				&:link {
 					h3 {
-						color: $brand_color_a;
+						color: $govuk-link-color;
 					}
 				}
 				&:hover {
 					h3 {
-						color: $brand_color_a;
+						color: $govuk-link-color;
 					}
 				}
 				&:active {
 					h3 {
-						color: $brand_color_a;
+						color: $govuk-link-color;
 					}
 				}
 				&:visited {
 					h3 {
-						color: $brand_color_b;
+						color: $govuk-link-visited-color;
 					}
 				}
 			}
@@ -42,7 +42,7 @@
 #feedback_container {
 	margin-top: 4em;
 	#feedbackToggle {
-		color: $brand_color_a;
+		color: $govuk-link-color;
 	}
 }
 

--- a/app/assets/stylesheets/digital-workspace-overrides/vars/_colours.scss
+++ b/app/assets/stylesheets/digital-workspace-overrides/vars/_colours.scss
@@ -8,3 +8,6 @@ $brand_chrome_a: #E7E7E7;
 $brand_chrome_b: #ABABAB;
 $brand_chrome_c: #454A4C;
 $brand_chrome_d: #404040;
+
+$govuk-link-color: #1d70b8;
+$govuk-link-visited-color: #4c2c92;


### PR DESCRIPTION
- Change profile bar to grey background
    The transparent red background lets too much of the pattern beneath
    through, leading to poor legibility
- Replace orange links with GOV.UK link colour/brand red
    The orange link colour is neither on brand nor does it provide
    decent contrast. This changes all links to current GOV.UK link blue