### PR TITLE
Improve tests and fix some deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'jasmine-rails'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,6 @@ GEM
     css_parser (1.7.0)
       addressable
     daemon (1.2.0)
-    database_cleaner (1.7.0)
     delayed_job (4.1.8)
       activesupport (>= 3.0, < 6.1)
     delayed_job_active_record (4.1.4)
@@ -505,7 +504,6 @@ DEPENDENCIES
   coffee-rails
   country_select
   daemon
-  database_cleaner
   delayed_job
   delayed_job_active_record
   dotenv-rails

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -149,9 +149,9 @@ class Person < ApplicationRecord
     email.split('@').first.gsub(/[\W]|[\d]/, '')
   end
 
-  scope :all_in_groups_scope, ->(groups) { PeopleInGroupsQuery.new(groups).call }
-
-  scope :all_in_subtree, ->(group) { PeopleInGroupsQuery.new(group.subtree_ids).call }
+  def self.all_in_subtree(group)
+    PeopleInGroupsQuery.new(group.subtree_ids).call
+  end
 
   def self.outside_subteams(group)
     unscope(:order)

--- a/lib/csv_publisher/user_behavior_report.rb
+++ b/lib/csv_publisher/user_behavior_report.rb
@@ -39,7 +39,7 @@ module CsvPublisher
 
       # e.g. peoplefinder_staging_user_behavior_report
       def default_file_name
-        Rails.application.class.parent_name.underscore +
+        Rails.application.class.module_parent_name.underscore +
           '_' +
           (ENV['ENV'] || Rails.env).downcase +
           '_' +

--- a/lib/geckoboard_publisher/report.rb
+++ b/lib/geckoboard_publisher/report.rb
@@ -46,7 +46,7 @@ module GeckoboardPublisher
     # geckoboard-ruby gem's dataset.find_or_create id attribute
     # e.g. peoplefinder-staging.total_profiles_report
     def id
-      Rails.application.class.parent_name.underscore +
+      Rails.application.class.module_parent_name.underscore +
         '-' +
         (ENV['ENV'] || Rails.env).downcase +
         '.' +

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe GroupsController, type: :controller do
         post :create, params: { group: attributes, format: :json }, session: valid_session
 
         expect(response.code).to eq '422'
-        expect(response.body).to eq '{"parent_id":["is required"]}'
+        expect(response.body).to eq '{"parent_id":["is required (a root group/department already exists)"]}'
       end
     end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Group, type: :model do
     create(:department)
     group = build(:group, parent: nil)
     expect(group.valid?).to eq false
-    expect(group.errors[:parent_id]).to eq ['is required']
+    expect(group.errors[:parent_id]).to eq ['is required (a root group/department already exists)']
     expect { group.save! }.to raise_error(Exception)
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,25 +56,6 @@ Dir[File.expand_path('controllers/concerns/shared_examples*.rb', __dir__)].sort.
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  config.use_transactional_fixtures = false
-
-  # Both Docker Compose and Travis CI use remote DB URLs
-  DatabaseCleaner.allow_remote_database_url = true
-
-  config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.before do |example|
-    DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
-    DatabaseCleaner.start
-  end
-
-  config.after do
-    DatabaseCleaner.clean
-  end
-
-  config.infer_spec_type_from_file_location!
   config.include FactoryBot::Syntax::Methods
   config.include SpecSupport::Login
   config.include SpecSupport::Search
@@ -87,4 +68,10 @@ RSpec.configure do |config|
   config.include SpecSupport::FeatureFlags
   config.include SpecSupport::AppConfig
   config.include SpecSupport::GeckoboardHelper
+
+  config.infer_spec_type_from_file_location!
+
+  # This enable Rails's `use_transactional_tests` (for legacy reasons, it hasn't been renamed
+  # in RSpec config)
+  config.use_transactional_fixtures = true
 end


### PR DESCRIPTION
- Remove pointless `database_cleaner` gem (this gem just replicates
  Rails's built in "transactional tests" functionality, no idea why
  it was ever added to this project)
- Fix convoluted root group validation and AR scope deprecation warning
- Remove unused `Person.all_in_groups_scope`
- Make `Person.all_in_subtree` class method instead of scope to fix
  deprecation issues
- Use `module_parent_name` instead of `parent_name` to fix deprecation
  warning