### PR TITLE
Downgrade CloudFoundry buildpack to 1.8.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,14 +436,14 @@ GEM
     sexp_processor (4.13.0)
     shoulda-matchers (4.2.0)
       activesupport (>= 4.2.0)
-    simplecov (0.18.0)
+    simplecov (0.18.1)
       docile (~> 1.1)
       simplecov-html (~> 0.11.0)
     simplecov-html (0.11.0)
-    site_prism (3.4.1)
+    site_prism (3.4.2)
       addressable (~> 2.5)
       capybara (~> 3.3)
-      site_prism-all_there (~> 0.3)
+      site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
     sixarm_ruby_unaccent (1.2.0)
     sort_alphabetical (1.1.0)
@@ -581,4 +581,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.1.3

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
-- buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.6
+- buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
   stack: cflinuxfs3


### PR DESCRIPTION
The deploy is failing due to an issue with the lastest buildpacks'
integration with Bundler 2.x. Downgrading buildpack for now.

c.f. https://github.com/cloudfoundry/ruby-buildpack/issues/120