### PR TITLE
Fix Rails 6.1 deprecations in test suite

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
 
   factory :department, class: 'Group' do
     initialize_with do
-      Group.where(ancestry_depth: 0).first_or_create(name: 'Department for International Trade')
+      Group.roots.first || Group.create(name: 'Department for International Trade')
     end
   end
 

--- a/spec/form_builders/person_form_builder_spec.rb
+++ b/spec/form_builders/person_form_builder_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe PersonFormBuilder, type: :form_builder do
   let(:object) { Object.new }
-  let(:template) { ActionView::Base.new }
+  let(:lookup_context) { ActionView::LookupContext.new(nil) }
+  let(:template) { ActionView::Base.new(lookup_context) }
   let(:options) { {} }
   let(:builder) { described_class.new(:person, object, template, options) }
 


### PR DESCRIPTION
- The `Group(:department)` factory uses `find_or_create` on a leaky
  scope, which was supported until now but will be fixed in Rails 6.1
- The `PersonFormBuilder` spec needs a (nil) lookup context to be
  provided