### PR TITLE
Change session storage to Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,11 +20,15 @@ PROFILE_API_TOKEN=profile_api_token
 #   REQUIRED - You can obtain test tokens from the GOV.UK Notify admin interface
 GOVUK_NOTIFY_API_KEY=
 
-# Database and Elasticsearch URLs
+# Database, Redis, and Elasticsearch URLs
 #   REQUIRED - but if you're running through Docker Compose these are set there
+#   It's fine to run cache and sidekiq on the same Redis instance in development,
+#   but in production we separate them out
 ES_URL=
 DATABASE_URL=
 TEST_DATABASE_URL=
+REDIS_CACHE_URL=
+REDIS_SIDEKIQ_URL=
 
 # URL for Digital Workspace frontend app
 HOME_PAGE_URL=http://localhost:4000

--- a/.reek.yml
+++ b/.reek.yml
@@ -102,6 +102,8 @@ detectors:
     - Zendesk#report_problem
     - Zendesk#request_deletion
     - GovukElementsErrorsHelperExtensions#error_html_attributes
+    - VcapServices#named_service_url
+    - VcapServices#service_url
     - InitSchema#up
     - DeleteQueuedNotifications#change
   InstanceVariableAssumption:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ ruby '2.6.5'
 #  the whole of `rails` as a dependency.
 gem 'rails', '~> 6.0.2'
 
-gem 'activerecord-session_store'
 gem 'ancestry'
 gem 'carrierwave'
 gem 'country_select'
@@ -36,6 +35,7 @@ gem 'paper_trail'
 gem 'pg'
 gem 'puma'
 gem 'pundit'
+gem 'redis'
 gem 'sass-rails'
 gem 'sentry-raven'
 gem 'sprockets', '~> 3' # TODO: Pinned due to asset issues with >= 4.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,12 +45,6 @@ GEM
     activerecord (6.0.2.1)
       activemodel (= 6.0.2.1)
       activesupport (= 6.0.2.1)
-    activerecord-session_store (1.1.3)
-      actionpack (>= 4.0)
-      activerecord (>= 4.0)
-      multi_json (~> 1.11, >= 1.11.2)
-      rack (>= 1.5.2, < 3)
-      railties (>= 4.0)
     activestorage (6.0.2.1)
       actionpack (= 6.0.2.1)
       activejob (= 6.0.2.1)
@@ -321,6 +315,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.1.3)
     reek (5.6.0)
       codeclimate-engine-rb (~> 0.4.0)
       kwalify (~> 0.7.0)
@@ -456,7 +451,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-session_store
   ancestry
   brakeman
   byebug
@@ -495,6 +489,7 @@ DEPENDENCIES
   rails (~> 6.0.2)
   rails-controller-testing
   rails_12factor
+  redis
   reek
   rspec-json_expectations
   rspec-rails (~> 4.0.0beta4)

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,10 +50,12 @@ module Peoplefinder
     config.x.zendesk.service_id = ENV['ZD_SERVICE_ID']
     config.x.zendesk.service_name = ENV['ZD_SERVICE_NAME']
 
-    config.elastic_search_url = ENV['ES_URL']
+    config.elastic_search_url = ENV['ES_URL'] # Overridden in production config
     config.google_analytics_tracking_id = ENV['GA_TRACKING_ID']
     config.govuk_notify_api_key = ENV['GOVUK_NOTIFY_API_KEY']
     config.home_page_url = ENV['HOME_PAGE_URL']
     config.profile_api_token = ENV['PROFILE_API_TOKEN']
+    config.redis_cache_url = ENV['REDIS_CACHE_URL'] # Overridden in production config
+    config.redis_sidekiq_url = ENV['REDIS_SIDEKIQ_URL'] # Overridden in production config
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
+  # CloudFoundry Services
+  vcap_services = VcapServices.new(ENV['VCAP_SERVICES'])
+  config.elastic_search_url = vcap_services.service_url(:elasticsearch)
+  config.redis_cache_url = vcap_services.named_service_url(:redis, 'redis-peoplefinder-cache')
+  config.redis_sidekiq_url = vcap_services.named_service_url(:redis, 'redis-peoplefinder-sidekiq')
+
+  # Production caching and sessions through Redis Cache
+  config.cache_store = :redis_cache_store, { url: config.redis_cache_url }
+  config.session_store :cache_store,
+                       key: 'peoplefinder_session',
+                       expire_after: 1.hour,
+                       httponly: true
+
   config.force_ssl = true
   config.cache_classes = true
   config.eager_load = true

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,8 +1,3 @@
 # frozen_string_literal: true
 
-if Rails.env.production?
-  vcap_elasticsearch = JSON.parse(ENV['VCAP_SERVICES'])['elasticsearch'].first
-  Elasticsearch::Model.client = Elasticsearch::Client.new(url: vcap_elasticsearch['credentials']['uri'])
-elsif Rails.configuration.elastic_search_url
-  Elasticsearch::Model.client = Elasticsearch::Client.new(url: Rails.configuration.elastic_search_url)
-end
+Elasticsearch::Model.client = Elasticsearch::Client.new(url: Rails.configuration.elastic_search_url)

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -12,4 +12,14 @@ HealthCheck.setup do |config|
   config.add_custom_check('elasticsearch') do
     HealthCheck::ElasticsearchHealthCheck.check
   end
+
+  config.add_custom_check('redis_cache') do
+    res = ::Redis.new(url: Rails.configuration.redis_cache_url).ping
+    res == 'PONG' ? '' : "Redis.ping returned #{res.inspect} instead of PONG"
+  end
+
+  config.add_custom_check('redis_sidekiq') do
+    res = ::Redis.new(url: Rails.configuration.redis_sidekiq_url).ping
+    res == 'PONG' ? '' : "Redis.ping returned #{res.inspect} instead of PONG"
+  end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# Be sure to restart your server when you modify this file.
-
-Rails.application.config.session_store :active_record_store, key: '_dit_peoplefinder_session'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     volumes:
       # Volume set to `delegated` to improve performance (container FS authoritative)
       - ./tmp/db:/var/lib/postgresql/data:delegated
+  redis_cache_sidekiq:
+    image: redis
   web:
     build: .
     # The pidfile often ends up not being deleted on shutdown, there's no reason to
@@ -17,6 +19,8 @@ services:
       DATABASE_URL: "postgres://postgres:postgres@db/peoplefinder_development"
       TEST_DATABASE_URL: "postgres://postgres:postgres@db/peoplefinder_test"
       ES_URL: "http://elasticsearch:9200"
+      REDIS_CACHE_URL: "redis://redis_cache_sidekiq"
+      REDIS_SIDEKIQ_URL: "redis://redis_cache_sidekiq"
     volumes:
       # Volume set to `delegated` to improve performance (container FS authoritative)
       - .:/peoplefinder:delegated
@@ -25,6 +29,7 @@ services:
     depends_on:
       - db
       - elasticsearch
+      - redis_cache_sidekiq
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.6.0
     environment:

--- a/lib/vcap_services.rb
+++ b/lib/vcap_services.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Retrieve service URLs from CloudFoundry VCAP_SERVICES
+class VcapServices
+  def initialize(vcap_services_env)
+    @services = JSON.parse(vcap_services_env)
+  end
+
+  def service_url(service_type)
+    candidates = services_of_type(service_type)
+    return nil if candidates.blank?
+
+    candidates.first.dig('credentials', 'uri')
+  end
+
+  def named_service_url(service_type, binding_name)
+    # TODO: For some bizarre reason, binding names do not seem to persist reliably on CloudFoundry.
+    #       Until this gets fixed, we need to establish named services by name instead of binding name,
+    #       which means we need to disregard the last part of the name (which is usually an environment
+    #       suffix).
+    candidates = services_of_type(service_type).select { |service| service['name'].start_with?(binding_name) }
+    return nil if candidates.blank?
+
+    candidates.first.dig('credentials', 'uri')
+  end
+
+  private
+
+  def services_of_type(service_type)
+    @services[service_type.to_s] || []
+  end
+end

--- a/spec/fixtures/files/vcap_services.json
+++ b/spec/fixtures/files/vcap_services.json
@@ -1,0 +1,90 @@
+{
+  "elasticsearch": [
+   {
+    "binding_name": null,
+    "credentials": {
+     "hostname": "es_host",
+     "password": "es_pass",
+     "port": "es_port",
+     "uri": "es_uri",
+     "username": "es_user"
+    },
+    "instance_name": "es_instance_name",
+    "label": "elasticsearch",
+    "name": "es_name",
+    "plan": "es_plan",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [],
+    "volume_mounts": []
+   }
+  ],
+  "postgres": [
+   {
+    "binding_name": null,
+    "credentials": {
+     "host": "pg_host",
+     "jdbcuri": "pg_jdbc",
+     "name": "pg_name",
+     "password": "pg_pass",
+     "port": "pg_port",
+     "uri": "pg_uri",
+     "username": "pg_user"
+    },
+    "instance_name": "pg_instance_name",
+    "label": "postgres",
+    "name": "pg_name",
+    "plan": "pg_plan",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [
+     "postgres"
+    ],
+    "volume_mounts": []
+   }
+  ],
+  "redis": [
+   {
+    "binding_name": "redis-cache",
+    "credentials": {
+     "host": "redis_cache_host",
+     "name": "redis_cache_name",
+     "password": "redis_cache_pass",
+     "port": "redis_cache_port",
+     "tls_enabled": true,
+     "uri": "redis_cache_uri"
+    },
+    "instance_name": "redis_cache_instance_name",
+    "label": "redis",
+    "name": "redis_cache_name",
+    "plan": "redis_cache_plan",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [
+     "redis"
+    ],
+    "volume_mounts": []
+   },
+   {
+    "binding_name": "redis-sidekiq",
+    "credentials": {
+     "host": "redis_sidekiq_host",
+     "name": "redis_sidekiq_name",
+     "password": "redis_sidekiq_pass",
+     "port": "redis_sidekiq_port",
+     "tls_enabled": true,
+     "uri": "redis_sidekiq_uri"
+    },
+    "instance_name": "redis_sidekiq_instance_name",
+    "label": "redis",
+    "name": "redis_sidekiq_name",
+    "plan": "redis_sidekiq_plan",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [
+     "redis"
+    ],
+    "volume_mounts": []
+   }
+  ]
+}

--- a/spec/lib/vcap_services_spec.rb
+++ b/spec/lib/vcap_services_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VcapServices do
+  subject { described_class.new(env_var) }
+
+  let(:env_var) { file_fixture('vcap_services.json').read }
+
+  describe '#service_url' do
+    context 'when there is only one service of the given type' do
+      let(:service_url) { subject.service_url(:elasticsearch) }
+
+      it 'gets the url for the service of the given type' do
+        expect(service_url).to eq('es_uri')
+      end
+    end
+
+    context 'when there are multiple services of the given type' do
+      let(:service_url) { subject.service_url(:redis) }
+
+      it 'gets the url for the first service of the given type' do
+        expect(service_url).to eq('redis_cache_uri')
+      end
+    end
+
+    context 'when there are no services of the given type' do
+      let(:service_url) { subject.service_url(:ms_sql_server_2008) }
+
+      it 'returns nil' do
+        expect(service_url).to be_nil
+      end
+    end
+  end
+
+  describe '#named_service_url' do
+    context 'for a service with a binding name that exists' do
+      let(:named_service_url) { subject.named_service_url(:redis, 'redis_sidekiq') }
+
+      it 'gets the url for the service of the given type and binding name' do
+        expect(named_service_url).to eq('redis_sidekiq_uri')
+      end
+    end
+
+    context 'for a service with a binding name that does not exist' do
+      let(:named_service_url) { subject.named_service_url(:redis, 'redis_foo') }
+
+      it 'returns nil' do
+        expect(named_service_url).to be_nil
+      end
+    end
+
+    context 'when there are no services of the given type' do
+      let(:named_service_url) { subject.named_service_url(:ms_sql_server_2008, 'foo') }
+
+      it 'returns nil' do
+        expect(named_service_url).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're currently storing sessions in the database, which isn't our
preferred way, and isn't being cleaned up properly.

- Add Redis gem
- Clean up Elasticsearch VCAP_SERVICES config
- Add VCAP Services helper library
- Use new VCAP Services helper for Elasticsearch
- Add Redis configuration
- Update env example and docker compose
- Store sessions in cache; not DB
- Expire sessions after 1 hour