### PR TITLE
Change ActiveJob to use Sidekiq

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -93,7 +93,6 @@ detectors:
     - StateCookieHelper#set_state_cookie_action_update_if_not_create
     - StateCookieHelper#set_state_cookie_picture_editing_complete
     - VersionsHelper#link_to_edited_item
-    - UpdateGroupMembersCompletionScoreJob#error_handler
     - Group#average_completion_score
     - Version#reify
     - GroupLister#list
@@ -102,8 +101,6 @@ detectors:
     - Zendesk#report_problem
     - Zendesk#request_deletion
     - GovukElementsErrorsHelperExtensions#error_html_attributes
-    - VcapServices#named_service_url
-    - VcapServices#service_url
     - InitSchema#up
     - DeleteQueuedNotifications#change
   InstanceVariableAssumption:
@@ -379,6 +376,7 @@ detectors:
     - PeopleHelper#url_for_image
     - SearchHelper#count_as_string
     - VersionsHelper#view_template
+    - UpdateGroupMembersCompletionScoreJob#error_handler
     - UpdateGroupMembersCompletionScoreJob#perform
     - Completion#inadequate_profiles_sql
     - Completion#where_people_in

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'pundit'
 gem 'redis'
 gem 'sass-rails'
 gem 'sentry-raven'
+gem 'sidekiq'
 gem 'sprockets', '~> 3' # TODO: Pinned due to asset issues with >= 4.0
 gem 'uglifier'
 gem 'useragent'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.5)
+    connection_pool (2.2.2)
     countries (3.0.0)
       i18n_data (~> 0.8.0)
       sixarm_ruby_unaccent (~> 1.1)
@@ -273,6 +274,8 @@ GEM
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     rack (2.1.2)
+    rack-protection (2.0.8.1)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.2.1)
@@ -387,6 +390,11 @@ GEM
     sexp_processor (4.13.0)
     shoulda-matchers (4.2.0)
       activesupport (>= 4.2.0)
+    sidekiq (6.0.5)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     simplecov (0.18.1)
       docile (~> 1.1)
       simplecov-html (~> 0.11.0)
@@ -501,6 +509,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   shoulda-matchers
+  sidekiq
   simplecov
   site_prism
   sprockets (~> 3)

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module Peoplefinder
 
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
 
-    config.active_job.queue_adapter = :delayed_job
+    config.active_job.queue_adapter = :sidekiq
     config.active_record.schema_format = :ruby
     config.assets.paths << Rails.root.join('vendor', 'assets', 'components')
     config.autoload_paths << Rails.root.join('lib')

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: Rails.configuration.redis_sidekiq_url }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: Rails.configuration.redis_sidekiq_url }
+end

--- a/spec/jobs/update_group_members_completion_score_job_spec.rb
+++ b/spec/jobs/update_group_members_completion_score_job_spec.rb
@@ -28,11 +28,6 @@ RSpec.describe UpdateGroupMembersCompletionScoreJob, type: :job do
     it 'enqueues with group params' do
       expect(subject).to have_enqueued_job.with(group)
     end
-
-    it 'checks job is not already enqueued' do
-      expect_any_instance_of(described_class).to receive(:enqueued?).with group
-      described_class.perform_later(group)
-    end
   end
 
   describe '#error_handler' do
@@ -44,13 +39,6 @@ RSpec.describe UpdateGroupMembersCompletionScoreJob, type: :job do
 
     it 'rescues from ActiveJob::DeserializationError' do
       expect_any_instance_of(described_class).to receive(:error_handler).with(ActiveJob::DeserializationError)
-      perform_enqueued_jobs { enqueue_job }
-    end
-
-    it 'logs the error' do
-      logger = double
-      expect(Rails).to receive(:logger).and_return(logger)
-      expect(logger).to receive(:warn).with(/#{described_class}/)
       perform_enqueued_jobs { enqueue_job }
     end
 


### PR DESCRIPTION
- Add sidekiq gem
- Configure Sidekiq to use dedicated Redis instance
- Swap ActiveJob configuration to use Sidekiq
- Remove over-the-top duplicate job checking from
  `UpdateMembersCompletionScoreJob`