### PR TITLE
Downgrade Sidekiq until GOV.UK PaaS supports Redis 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'pundit'
 gem 'redis'
 gem 'sass-rails'
 gem 'sentry-raven'
-gem 'sidekiq'
+gem 'sidekiq', '< 6' # TODO: Pinned because 6.0 requires Redis 4 which PaaS doesn't provide yet
 gem 'sprockets', '~> 3' # TODO: Pinned due to asset issues with >= 4.0
 gem 'uglifier'
 gem 'useragent'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,11 +385,11 @@ GEM
     sexp_processor (4.13.0)
     shoulda-matchers (4.2.0)
       activesupport (>= 4.2.0)
-    sidekiq (6.0.5)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.18.1)
       docile (~> 1.1)
       simplecov-html (~> 0.11.0)
@@ -502,7 +502,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   shoulda-matchers
-  sidekiq
+  sidekiq (< 6)
   simplecov
   site_prism
   sprockets (~> 3)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,9 @@
 
 Sidekiq.configure_server do |config|
   config.redis = { url: Rails.configuration.redis_sidekiq_url }
-  config.log_formatter = Sidekiq::Logger::Formatters::JSON.new
+
+  # TODO: Enable once we can upgrade to Sidekiq 6.0
+  # config.log_formatter = Sidekiq::Logger::Formatters::JSON.new
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
The latest version of Sidekiq requires Redis 4.0 or higher – PaaS is
stuck on 3.x.