### PR TITLE
Replicate Workspace search bar in new frontend

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -27,3 +27,12 @@ header.govuk-header.govuk-header--ws[role="banner" data-module="govuk-header"]
               = link_to 'Manage', admin_home_path, class: 'govuk-header__link govuk-header__link--ws'
           li.govuk-header__navigation-item.govuk-header__navigation-item--mobile-only
             = link_to "My profile (#{current_user.given_name})", person_path(current_user), class: 'govuk-header__link govuk-header__link--ws'
+
+      div.ws-legacy-workspace-search
+        .ws-search-field
+          = form_tag home_page_link_helper('search'), method: :get do
+            label.govuk-visually-hidden[for="search-main"] Search site
+            .ws-search-field__item-wrapper
+              = search_field_tag :query, @query, class: 'ws-search-field__item ws-search-field__input', id: 'search-workspace', placeholder: 'Search site'
+              .ws-search-field__item.ws-search-field__submit-wrapper
+                = submit_tag 'Search', class: 'ws-search-field__submit'

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import "govuk-overrides/header";
 
 // Components
+@import "components/legacy_workspace_search";
 @import "components/search_and_profile_bar";
 @import "components/search_field";
 

--- a/app/webpacker/stylesheets/components/legacy_workspace_search.scss
+++ b/app/webpacker/stylesheets/components/legacy_workspace_search.scss
@@ -1,0 +1,28 @@
+// Recreates the ugly separate search field for legacy Digital Workspace
+// TODO: Remove once "combined search" is rolled out
+
+.ws-legacy-workspace-search {
+  position: absolute;
+  top: 8px;
+  right: 0;
+
+  display: none;
+  width: 300px;
+
+  border: 2px solid #000000;
+
+
+  @include govuk-media-query($from: tablet) {
+    display: block;
+  }
+
+  .ws-search-field__input[type="search"] {
+    height: 36px;
+  }
+
+  .ws-search-field__submit {
+    height: 36px;
+
+    background-color: govuk-colour("blue");
+  }
+}


### PR DESCRIPTION
As we do not yet have a deployed combined search application, we need to
replicate the awful top-right-of-page separate search bar for now.