### PR TITLE
Only specify needed Rails gems in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,13 @@
 source 'https://rubygems.org'
 ruby '2.6.5'
 
-# TODO: Only load the subgems we need
-#  This is currently not possible because some `govuk_*` gems wrongly specify
-#  the whole of `rails` as a dependency.
-gem 'rails', '~> 6.0.2'
+RAILS_VERSION = '~> 6.0.2'
+gem 'actionpack', RAILS_VERSION
+gem 'activemodel', RAILS_VERSION
+gem 'activejob', RAILS_VERSION
+gem 'activerecord', RAILS_VERSION
+gem 'activesupport', RAILS_VERSION
+gem 'railties', RAILS_VERSION
 
 gem 'ancestry'
 gem 'carrierwave'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack (~> 6.0.2)
+  activejob (~> 6.0.2)
+  activemodel (~> 6.0.2)
+  activerecord (~> 6.0.2)
+  activesupport (~> 6.0.2)
   ancestry
   brakeman
   byebug
@@ -466,8 +471,8 @@ DEPENDENCIES
   pry-rails
   puma
   pundit
-  rails (~> 6.0.2)
   rails-controller-testing
+  railties (~> 6.0.2)
   redis
   rspec-json_expectations
   rspec-rails (~> 4.0.0beta4)


### PR DESCRIPTION
This won't improve gem installation performance yet, as some legacy
dependencies still incorrectly require _all_ of Rails.