### PR TITLE
Remove IP and browser info from user-facing audit trail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'redis'
 gem 'sentry-raven'
 gem 'sidekiq', '< 6' # TODO: Pinned because 6.0 requires Redis 4 which PaaS doesn't provide yet
 gem 'slim'
-gem 'useragent'
 gem 'webpacker'
 gem 'will_paginate'
 gem 'zendesk_api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,7 +402,6 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.1)
     unicode_utils (1.4.0)
-    useragent (0.16.10)
     webmock (3.8.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -494,7 +493,6 @@ DEPENDENCIES
   sprockets (~> 3)
   timecop
   uglifier
-  useragent
   webmock
   webpacker
   whenever-test

--- a/app/presenters/audit_version_presenter.rb
+++ b/app/presenters/audit_version_presenter.rb
@@ -2,12 +2,10 @@
 
 require 'forwardable'
 require 'yaml'
-require 'user_agent'
 
 class AuditVersionPresenter
   extend Forwardable
-  def_delegators :@version, :event, :whodunnit, :created_at, :ip_address,
-                 :user_agent
+  def_delegators :@version, :event, :whodunnit, :created_at
 
   def initialize(version)
     @version = version
@@ -18,13 +16,6 @@ class AuditVersionPresenter
       value = new.presence || '(deleted)'
       [field, value]
     end
-  end
-
-  def user_agent_summary
-    return nil if user_agent.blank?
-
-    ua = UserAgent.parse(user_agent)
-    format('%s %s', ua.browser, ua.version)
   end
 
   def self.wrap(versions)

--- a/app/views/shared/_audit.html.slim
+++ b/app/views/shared/_audit.html.slim
@@ -7,8 +7,6 @@ div.govuk-grid-column-full
       tr
         th.govuk-table__header Event at
         th.govuk-table__header By
-        th.govuk-table__header IP address
-        th.govuk-table__header Browser
         th.govuk-table__header Change
       - versions.reverse.each do |v|
         tr
@@ -18,8 +16,6 @@ div.govuk-grid-column-full
               = link_to v.whodunnit.to_s, v.whodunnit
             - else
               = v.whodunnit || 'Not available'
-          td.govuk-table__cell = v.ip_address
-          td.govuk-table__cell = v.user_agent_summary
           td.govuk-table__cell
             ul.govuk-list
               - v.changes.each do |field, value|

--- a/app/views/shared/_audit_legacy.html.haml
+++ b/app/views/shared/_audit_legacy.html.haml
@@ -10,10 +10,6 @@
           %th
             = "By"
           %th
-            = "IP address"
-          %th
-            = "Browser"
-          %th
             = "Change"
       %tbody
         - versions.reverse.each do |v|
@@ -26,10 +22,6 @@
             - else
               %td
                 = v.whodunnit || "Not available"
-            %td
-              = v.ip_address
-            %td{title: v.user_agent}
-              = v.user_agent_summary
             %td
               %ul
                 - v.changes.each do |field, value|

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -46,25 +46,6 @@ describe 'View person audit' do
           expect(v[0]).to have_link author.to_s, href: "/people/#{author.slug}"
         end
       end
-
-      it 'show IP address of author of a change' do
-        Version.last.update ip_address: '1.2.3.4'
-        profile_page.load(slug: person.slug)
-
-        profile_page.audit.versions.tap do |v|
-          expect(v[0]).to have_text '1.2.3.4'
-        end
-      end
-
-      it 'show browser used by author of a change' do
-        ua = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)'
-        Version.last.update user_agent: ua
-        profile_page.load(slug: person.slug)
-
-        profile_page.audit.versions.tap do |v|
-          expect(v[0]).to have_text 'Internet Explorer 6.0'
-        end
-      end
     end
 
     context 'as a regular user' do


### PR DESCRIPTION
This doesn't really add value to users - we don't need to display the
browser a user made a change from or what their IP is. We log this stuff
anyway through other mechanisms, and we can keep it around in the DB for
now as `paper_trail` tracks it anyway, but we shouldn't show superfluous
information for the sake of it.