### PR TITLE
Make user roles more granular

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,11 +50,6 @@ class ApplicationController < ActionController::Base
   end
   helper_method :logged_in?
 
-  def super_admin?
-    logged_in? && current_user.super_admin?
-  end
-  helper_method :super_admin?
-
   def ensure_user
     return true if logged_in?
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -128,7 +128,7 @@ class GroupsController < ApplicationController
   end
 
   def versions
-    @versions ||= AuditVersionPresenter.wrap(group.versions) if super_admin?
+    @versions ||= AuditVersionPresenter.wrap(group.versions) if policy(group).edit?
   end
 
   def group_params

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -90,14 +90,14 @@ class PeopleController < ApplicationController
       building: [], key_skills: [], learning_and_development: [], networks: [],
       key_responsibilities: [], additional_responsibilities: [], professions: [],
       memberships_attributes: %i[id role group_id leader _destroy]
-    ] + super_admin_person_params
+    ] + administrator_person_params
   end
 
-  def super_admin_person_params
-    # Parameters that can only be updated by super admins, not regular users
-    return [] unless super_admin?
+  def administrator_person_params
+    # Parameters that can only be updated by administrators, not regular users
+    return [] unless current_user.role_administrator?
 
-    %i[super_admin ditsso_user_id]
+    %i[role_administrator role_people_editor role_groups_editor ditsso_user_id]
   end
 
   def set_org_structure
@@ -121,6 +121,6 @@ class PeopleController < ApplicationController
   def load_versions
     versions = @person.versions
     @last_updated_at = versions.last ? versions.last.created_at : nil
-    @versions = AuditVersionPresenter.wrap(versions) if super_admin?
+    @versions = AuditVersionPresenter.wrap(versions) if policy(@person).audit?
   end
 end

--- a/app/policies/admin/management_policy.rb
+++ b/app/policies/admin/management_policy.rb
@@ -9,11 +9,11 @@ module Admin
     end
 
     def show?
-      admin_user?
+      administrator?
     end
 
     def csv_extract_report?
-      admin_user?
+      administrator?
     end
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -10,11 +10,15 @@ class ApplicationPolicy
 
   private
 
-  def admin_user?
-    @user.is_a?(Person) && @user.super_admin?
+  def people_editor?
+    @user.is_a?(Person) && @user.role_people_editor?
   end
 
-  def regular_user?
-    @user.is_a?(Person)
+  def groups_editor?
+    @user.is_a?(Person) && @user.role_groups_editor?
+  end
+
+  def administrator?
+    @user.is_a?(Person) && @user.role_administrator?
   end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -18,22 +18,22 @@ class GroupPolicy < ApplicationPolicy
   end
 
   def edit?
-    admin_user?
+    administrator? || groups_editor?
   end
 
   def update?
-    admin_user?
+    administrator? || groups_editor?
   end
 
   def new?
-    admin_user?
+    administrator? || groups_editor?
   end
 
   def create?
-    admin_user?
+    administrator? || groups_editor?
   end
 
   def destroy?
-    admin_user?
+    administrator? || groups_editor?
   end
 end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -6,30 +6,30 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def edit?
-    regular_user?
+    true
   end
 
   def update?
-    regular_user?
-  end
-
-  def update_email?
     true
   end
 
   def new?
-    regular_user?
+    true
   end
 
   def create?
-    regular_user?
+    true
   end
 
   def destroy?
-    admin_user?
+    administrator? || people_editor?
   end
 
   def add_membership?
-    regular_user?
+    true
+  end
+
+  def audit?
+    administrator? || people_editor?
   end
 end

--- a/app/policies/version_policy.rb
+++ b/app/policies/version_policy.rb
@@ -2,10 +2,10 @@
 
 class VersionPolicy < ApplicationPolicy
   def index?
-    admin_user?
+    administrator?
   end
 
   def undo?
-    admin_user?
+    administrator?
   end
 end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -22,7 +22,7 @@ header.govuk-header.govuk-header--ws[role="banner" data-module="govuk-header"]
             = link_to 'Tools', home_page_link_helper('/tools'), class: 'govuk-header__link govuk-header__link--ws'
           li.govuk-header__navigation-item
             = link_to 'Data Hub', home_page_link_helper('/working-at-dit/data-hub'), class: 'govuk-header__link govuk-header__link--ws'
-          - if super_admin?
+          - if current_user.role_administrator?
             li.govuk-header__navigation-item
               = link_to 'Manage', admin_home_path, class: 'govuk-header__link govuk-header__link--ws'
           li.govuk-header__navigation-item.govuk-header__navigation-item--mobile-only

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -167,20 +167,23 @@
       = link_to 'Cancel and go back', @person.new_record? ? :back : @person
 
 
-- if super_admin?
+- if current_user.role_administrator?
   = form_for @person, builder: PersonFormBuilder, html: { class: person_form_class(@person, @activity) } do |f|
     .form-group
       %h3.heading-medium.with-border-lg Administrative options
 
       = f.text_field :ditsso_user_id
 
+      %h4.heading-small Permissions
+
       %fieldset#admin-options
+        = f.check_box :role_groups_editor
+        = f.check_box :role_people_editor
+
         %p
           %span.form-hint
-            Administrators ("super admins") on People Finder can manage teams, delete profiles, and
-            view detailed audit trails, reports, and debugging information.
-            %strong.bold-term Only assign this permission to members of the Digital Workspace team.
-
-        = f.check_box :super_admin
+            Administrators on People Finder can view global audit trails, reports, and debugging information as well as
+            perform all groups and people management functions.
+        = f.check_box :role_administrator
 
       = f.submit 'Update permissions', class: 'button-danger', data: { confirm: "Are you sure you want to update #{@person.name}'s permissions?" }

--- a/app/views/people/_profile.html.haml
+++ b/app/views/people/_profile.html.haml
@@ -187,7 +187,7 @@
             %dd
               = @person.formatted_additional_responsibilities
 
-        - if super_admin?
+        - if current_user.role_administrator?
           %hr
           %dl.inline-labels#sso_user_id
             %dt Staff SSO User ID
@@ -197,9 +197,9 @@
             %dt People Finder Database ID
             %dd= @person.id
 
-          %dl.inline-labels#is_super_admin
-            %dt User is super admin?
-            %dd= @person.super_admin? ? 'Yes' : 'No'
+          %dl.inline-labels#is_administrator
+            %dt User has administrator role?
+            %dd= @person.role_administrator? ? 'Yes' : 'No'
 
           %dl.inline-labels#last_login_at
             %dt Last signed in to People Finder

--- a/app/views/search/_person.html.haml
+++ b/app/views/search/_person.html.haml
@@ -3,7 +3,7 @@
     .media
       .media-left
         = profile_image_tag person
-        - if Rails.env.development? || current_user.super_admin?
+        - if Rails.env.development? || current_user.role_administrator?
           %div.core-16
             Score:
             = hit._score

--- a/app/views/widgets/_nav.html.haml
+++ b/app/views/widgets/_nav.html.haml
@@ -17,6 +17,6 @@
     %li
       %a{:href => home_page_link_helper('/working-at-dit/data-hub')}
         Data Hub
-    - if super_admin?
+    - if current_user.role_administrator?
       %li
         = link_to 'Manage', admin_home_path, class: "manage-link"

--- a/config/locales/legacy.en.yml
+++ b/config/locales/legacy.en.yml
@@ -355,7 +355,9 @@ en:
         other_uk: Other - UK regional
         other_overseas: Other - Overseas
         other_additional_responsibilities: Other additional roles and responsibilities
-        super_admin: Allow this person to administrate People Finder
+        role_administrator: Allow this person to administrate People Finder
+        role_groups_editor: Allow this person to manage teams
+        role_people_editor: Allow this person to manage people
         ditsso_user_id: Staff SSO user ID
         line_manager: Manager
         line_manager_not_required: My manager is not listed because I do not work for DIT

--- a/db/migrate/20200324114928_add_roles_to_people.rb
+++ b/db/migrate/20200324114928_add_roles_to_people.rb
@@ -1,0 +1,7 @@
+class AddRolesToPeople < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :people, :super_admin, :role_administrator
+    add_column :people, :role_people_editor, :boolean, default: false
+    add_column :people, :role_groups_editor, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_19_135039) do
+ActiveRecord::Schema.define(version: 2020_03_24_114928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 2020_03_19_135039) do
     t.boolean "works_sunday", default: false
     t.integer "login_count", default: 0, null: false
     t.datetime "last_login_at"
-    t.boolean "super_admin", default: false
+    t.boolean "role_administrator", default: false
     t.text "city"
     t.integer "profile_photo_id"
     t.text "primary_phone_country_code"
@@ -86,6 +86,9 @@ ActiveRecord::Schema.define(version: 2020_03_19_135039) do
     t.string "pronouns"
     t.integer "line_manager_id"
     t.boolean "line_manager_not_required", default: false
+    t.string "user_role", default: "none"
+    t.boolean "role_people_editor", default: false
+    t.boolean "role_groups_editor", default: false
     t.index ["slug"], name: "index_people_on_slug", unique: true
   end
 

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 
 RSpec.describe PeopleController, type: :controller do
   before do |example|
-    mock_logged_in_user unless example.metadata[:user] == :super_admin
+    mock_logged_in_user unless example.metadata[:user] == :administrator
   end
 
-  before(:each, user: :super_admin) do
-    mock_logged_in_user super_admin: true
+  before(:each, user: :administrator) do
+    mock_logged_in_user administrator: true
   end
 
   # This should return the minimal set of attributes required to create a valid
@@ -92,14 +92,14 @@ RSpec.describe PeopleController, type: :controller do
       end
     end
 
-    describe 'when trying to grant super admin' do
+    describe 'when trying to grant administrator role' do
       let(:new_attributes) do
-        attributes_for(:person).merge(super_admin: true)
+        attributes_for(:person).merge(role_administrator: true)
       end
 
-      it 'does not grant super admin privileges' do
+      it 'does not grant the role' do
         person.reload
-        expect(person).not_to be_super_admin
+        expect(person).not_to be_role_administrator
       end
     end
   end
@@ -161,26 +161,26 @@ RSpec.describe PeopleController, type: :controller do
     end
 
     describe 'when trying to change super-admin only parameters' do
-      let(:attributes_with_super_admin) do
-        attributes_for(:super_admin).merge(ditsso_user_id: 'new_id')
+      let(:attributes_with_role_administrator) do
+        attributes_for(:administrator).merge(ditsso_user_id: 'new_id')
       end
 
       before do
-        put :update, params: { id: person.to_param, person: attributes_with_super_admin }
+        put :update, params: { id: person.to_param, person: attributes_with_role_administrator }
       end
 
-      context 'if the current user is not a super admin themselves' do
-        it 'does not grant super admin privileges' do
+      context 'if the current user is not an administrator themselves' do
+        it 'does not grant the role or update the SSO user id' do
           person.reload
-          expect(person).not_to be_super_admin
+          expect(person).not_to be_role_administrator
           expect(person.ditsso_user_id).not_to eq('new_id')
         end
       end
 
-      context 'if the current user IS a super user', user: :super_admin do
-        it 'grants super admin privileges' do
+      context 'if the current user IS a super user', user: :administrator do
+        it 'grants administrator role' do
           person.reload
-          expect(person).to be_super_admin
+          expect(person).to be_role_administrator
           expect(person.ditsso_user_id).to eq('new_id')
         end
       end
@@ -188,7 +188,7 @@ RSpec.describe PeopleController, type: :controller do
   end
 
   describe 'DELETE destroy' do
-    context 'as a super admin', user: :super_admin do
+    context 'as an administrator', user: :administrator do
       it 'destroys the requested person' do
         person = create(:person, valid_attributes)
         expect do

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe VersionsController, type: :controller do
       end
     end
 
-    context 'for a super admin' do
+    context 'for an administrator' do
       before do
-        mock_logged_in_user super_admin: true
+        mock_logged_in_user administrator: true
         get :index
       end
 
@@ -29,7 +29,7 @@ RSpec.describe VersionsController, type: :controller do
 
   describe '.undo' do
     before do
-      mock_logged_in_user super_admin: true
+      mock_logged_in_user administrator: true
     end
 
     it 'undoes a new person - by deleting it' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -112,8 +112,16 @@ FactoryBot.define do
       last_login_at { 1.day.ago }
     end
 
-    factory :super_admin do
-      super_admin { true }
+    factory :administrator do
+      role_administrator { true }
+    end
+
+    factory :groups_editor do
+      role_groups_editor { true }
+    end
+
+    factory :people_editor do
+      role_people_editor { true }
     end
   end
 

--- a/spec/features/audit_trail_spec.rb
+++ b/spec/features/audit_trail_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'Audit trail' do
   before do
-    omni_auth_log_in_as_super_admin
+    omni_auth_log_in_as_administrator
   end
 
   it 'Auditing an edit of a person' do

--- a/spec/features/csv_extract_spec.rb
+++ b/spec/features/csv_extract_spec.rb
@@ -2,10 +2,9 @@
 
 require 'rails_helper'
 
-describe 'Super admin views CSV extracts' do
+describe 'Administrator views CSV extracts' do
   before do
-    admin = create(:super_admin)
-    omni_auth_log_in_as(admin.ditsso_user_id)
+    omni_auth_log_in_as_administrator
     click_link 'Manage'
   end
 

--- a/spec/features/flash_spec.rb
+++ b/spec/features/flash_spec.rb
@@ -6,7 +6,7 @@ describe 'Flash messages' do
   let(:department) { create(:department) }
 
   before do
-    omni_auth_log_in_as_super_admin
+    omni_auth_log_in_as_administrator
   end
 
   it 'displays flash messages below search box' do

--- a/spec/features/group_audit_spec.rb
+++ b/spec/features/group_audit_spec.rb
@@ -15,9 +15,9 @@ describe 'Auditing changes to groups' do
     end
   end
 
-  context 'as an admin user' do
+  context 'as a groups editor' do
     before do
-      omni_auth_log_in_as_super_admin
+      omni_auth_log_in_as_groups_editor
     end
 
     it 'displays changes to the group' do

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -11,11 +11,11 @@ describe 'Group maintenance' do
     omni_auth_log_in_as '007'
   end
 
-  before(:each, user: :super_admin) do
-    omni_auth_log_in_as_super_admin
+  before(:each, user: :groups_editor) do
+    omni_auth_log_in_as_groups_editor
   end
 
-  context 'for a super admin', user: :super_admin, js: true do
+  context 'for an administrator', user: :groups_editor, js: true do
     let(:group_three_deep) { create(:group, name: 'Digital Services', parent: parent_group) }
     let(:sibling_group) { create(:group, name: 'Technology', parent: parent_group) }
     let(:parent_group) { create(:group, name: 'CSG', parent: dept) }

--- a/spec/features/login_flow_spec.rb
+++ b/spec/features/login_flow_spec.rb
@@ -31,7 +31,7 @@ describe 'Login flow' do
     end
 
     it 'When super user logs in they see the manage link in the banner' do
-      omni_auth_log_in_as_super_admin
+      omni_auth_log_in_as_administrator
       expect(base_page).to have_manage_link
     end
 

--- a/spec/features/management_spec.rb
+++ b/spec/features/management_spec.rb
@@ -8,14 +8,14 @@ describe 'Management flow' do
   let(:management_page) { Pages::Management.new }
 
   before do
-    omni_auth_log_in_as_super_admin
+    omni_auth_log_in_as_administrator
   end
 
-  it 'When a super admin logis in they have a manage link' do
+  it 'When an administrator logs in they have a manage link' do
     expect(base_page).to have_manage_link
   end
 
-  it 'Super admins can navigate to the management page' do
+  it 'Administrators can navigate to the management page' do
     expect(base_page).to have_manage_link
     click_link 'Manage'
     expect(management_page).to be_displayed

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -3,11 +3,8 @@
 require 'rails_helper'
 
 describe 'View person audit' do
-  let(:super_admin_email) { 'test.user@digital.justice.gov.uk' }
-  let!(:super_admin) { create(:super_admin, email: super_admin_email) }
-
   let(:phone_number) { '55555555555' }
-  let!(:person)      { with_versioning { create(:person) } }
+  let!(:person) { with_versioning { create(:person) } }
   let(:profile_page) { Pages::Profile.new }
 
   let(:profile_photo) { create(:profile_photo) }
@@ -23,9 +20,9 @@ describe 'View person audit' do
       end
     end
 
-    context 'as an admin user' do
+    context 'as a people editor' do
       before do
-        omni_auth_log_in_as(super_admin.ditsso_user_id)
+        omni_auth_log_in_as_people_editor
       end
 
       it 'view audit' do

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -7,15 +7,14 @@ describe 'Person maintenance' do
 
   let!(:department) { create(:department) }
   let(:person) { create(:person, :with_line_manager, email: 'test.user@digital.justice.gov.uk') }
-  let(:super_admin) { create(:super_admin, email: 'super.admin@digital.justice.gov.uk') }
   let(:another_person) { create(:person, email: 'someone.else@digital.justice.gov.uk') }
 
   before(:each, user: :regular) do
     omni_auth_log_in_as person.ditsso_user_id
   end
 
-  before(:each, user: :super_admin) do
-    omni_auth_log_in_as_super_admin
+  before(:each, user: :people_editor) do
+    omni_auth_log_in_as_people_editor
   end
 
   let(:edit_profile_page) { Pages::EditProfile.new }
@@ -156,7 +155,7 @@ describe 'Person maintenance' do
   end
 
   context 'Deleting a person' do
-    context 'for a super admin user', user: :super_admin do
+    context 'for a people editor', user: :people_editor do
       it 'Deleting a person' do
         person = create :person
 

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -7,8 +7,8 @@ describe 'Person maintenance' do
     omni_auth_log_in_as '007'
   end
 
-  before(:each, user: :super_admin) do
-    omni_auth_log_in_as_super_admin
+  before(:each, user: :groups_editor) do
+    omni_auth_log_in_as_groups_editor
   end
 
   let(:edit_profile_page) { Pages::EditProfile.new }
@@ -62,7 +62,7 @@ describe 'Person maintenance' do
     expect(person.memberships.last.group).to eql(Group.find_by(name: 'CSG'))
   end
 
-  it 'Adding a new team', js: true, user: :super_admin do
+  it 'Adding a new team', js: true, user: :groups_editor do
     group = setup_three_level_team
     person = setup_team_member group
 

--- a/spec/policies/admin/management_policy_spec.rb
+++ b/spec/policies/admin/management_policy_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Admin::ManagementPolicy, type: :policy do
   subject { described_class.new(user, nil) }
 
-  ACTIONS = %w[show csv_extract_report].map(&:to_sym)
+  ACTIONS = %i[show csv_extract_report].freeze
 
-  context 'for a super admin user' do
-    let(:user) { build_stubbed(:person, super_admin: true) }
+  context 'for an administrator' do
+    let(:user) { build_stubbed(:administrator) }
 
     ACTIONS.each do |action|
       it { is_expected.to permit_action(action) }
@@ -16,7 +16,7 @@ RSpec.describe Admin::ManagementPolicy, type: :policy do
   end
 
   context 'for a regular user' do
-    let(:user) { build_stubbed(:person, super_admin: false) }
+    let(:user) { build_stubbed(:person) }
 
     ACTIONS.each do |action|
       it { is_expected.not_to permit_action(action) }

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -21,8 +21,22 @@ RSpec.describe GroupPolicy, type: :policy do
     it { is_expected.not_to permit_action(:destroy) }
   end
 
-  context 'for a super admin' do
-    let(:user) { build_stubbed(:super_admin) }
+  context 'for a groups editor' do
+    let(:user) { build_stubbed(:groups_editor) }
+
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:all_people) }
+    it { is_expected.to permit_action(:people_outside_subteams) }
+    it { is_expected.to permit_action(:tree) }
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:destroy) }
+  end
+
+  context 'for an administrator' do
+    let(:user) { build_stubbed(:administrator) }
 
     it { is_expected.to permit_action(:show) }
     it { is_expected.to permit_action(:all_people) }

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -15,13 +15,34 @@ RSpec.describe PersonPolicy, type: :policy do
     it { is_expected.to permit_action(:update) }
     it { is_expected.to permit_action(:new) }
     it { is_expected.to permit_action(:create) }
-    it { is_expected.not_to permit_action(:destroy) }
     it { is_expected.to permit_action(:add_membership) }
+    it { is_expected.not_to permit_action(:destroy) }
+    it { is_expected.not_to permit_action(:audit) }
   end
 
-  context 'for a super admin user' do
-    let(:user) { build_stubbed(:super_admin) }
+  context 'for a people editor' do
+    let(:user) { build_stubbed(:people_editor) }
 
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:add_membership) }
     it { is_expected.to permit_action(:destroy) }
+    it { is_expected.to permit_action(:audit) }
+  end
+
+  context 'for an administrator' do
+    let(:user) { build_stubbed(:administrator) }
+
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:edit) }
+    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:add_membership) }
+    it { is_expected.to permit_action(:destroy) }
+    it { is_expected.to permit_action(:audit) }
   end
 end

--- a/spec/support/login.rb
+++ b/spec/support/login.rb
@@ -2,9 +2,9 @@
 
 module SpecSupport
   module Login
-    def mock_logged_in_user(super_admin: false)
+    def mock_logged_in_user(administrator: false)
       controller.session[::Login::SESSION_KEY] =
-        create(:person, ditsso_user_id: '007', super_admin: super_admin).id
+        create(:person, ditsso_user_id: '007', role_administrator: administrator).id
     end
 
     def current_user
@@ -29,8 +29,16 @@ module SpecSupport
       visit '/auth/ditsso_internal'
     end
 
-    def omni_auth_log_in_as_super_admin
-      omni_auth_log_in_as create(:super_admin).ditsso_user_id
+    def omni_auth_log_in_as_administrator
+      omni_auth_log_in_as create(:administrator).ditsso_user_id
+    end
+
+    def omni_auth_log_in_as_people_editor
+      omni_auth_log_in_as create(:people_editor).ditsso_user_id
+    end
+
+    def omni_auth_log_in_as_groups_editor
+      omni_auth_log_in_as create(:groups_editor).ditsso_user_id
     end
   end
 end


### PR DESCRIPTION
This isn't perfect and we need to move to a more flexible role-based system in the future, but for now, this adds less powerful "editor" roles for people and groups and renames the poorly named "super admin" to "administrator".

- Rename "super admin" to administrator role and add people/group editor roles
- Add ability to set groups/people editor permissions
- Update pundit policies for new roles