### PR TITLE
Don't fail login if user record fails to save

### DIFF
--- a/app/interactors/login_person.rb
+++ b/app/interactors/login_person.rb
@@ -33,6 +33,10 @@ class LoginPerson
 
   def save_person
     person.save!
+  rescue ActiveRecord::ActiveRecordError => e
+    # We don't want an error in saving the record (e.g. due to inconsistent state in DB) to fail creating a session
+    # (but we do want to keep track of these to make sure we can discover root causes)
+    Raven.capture_exception(e)
   end
 
   def person


### PR DESCRIPTION
The move to the new `LoginPerson` interactor changed the method of saving
from `#save` to `#save!` because the operation shouldn't really fail.

However, in cases where there is an existing inconsistent record in the
DB, this _can_ fail and cause an error, so we need to catch it (and ship
it off to Sentry so we can investigate those accounts where that happens).