### PR TITLE
Fix n+1 query on search results

### DIFF
--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -45,7 +45,7 @@ class PersonSearch
 
   def do_searches
     execute_search
-    @results.set = matches.records
+    @results.set = matches.records(includes: [:memberships])
     @results.contains_exact_match = exact_match_exists?
   end
 


### PR DESCRIPTION
The search code wasn't including memberships so the search results
would fetch membership records for every single result. The search
code needs to be rewritten eventually, but for now this will do.