### PR TITLE
Remove unused test/development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,15 +69,12 @@ end
 
 group :development, :test do
   gem 'brakeman', require: false
-  gem 'byebug'
   gem 'factory_bot_rails'
-  gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
-  gem 'simplecov'
   gem 'timecop'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,6 @@ GEM
     ast (2.4.0)
     brakeman (4.8.0)
     builder (3.2.4)
-    byebug (11.1.1)
     capybara (3.32.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -95,7 +94,6 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
     diff-lcs (1.3)
-    docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
@@ -281,9 +279,6 @@ GEM
     pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.3)
@@ -408,10 +403,6 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 2.0.0)
       redis (>= 4.1.0)
-    simplecov (0.18.5)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
     site_prism (3.4.2)
       addressable (~> 2.5)
       capybara (~> 3.3)
@@ -480,7 +471,6 @@ DEPENDENCIES
   activesupport (~> 6.0.2)
   ancestry
   brakeman
-  byebug
   capybara
   carrierwave
   country_select
@@ -512,7 +502,6 @@ DEPENDENCIES
   omniauth-oauth2
   paper_trail
   pg
-  pry-byebug
   pry-rails
   puma
   pundit
@@ -530,7 +519,6 @@ DEPENDENCIES
   sentry-raven
   shoulda-matchers
   sidekiq
-  simplecov
   site_prism
   slim
   sprockets (~> 3)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,21 +4,11 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
-require 'pry-byebug'
 require 'timecop'
 require 'paper_trail/frameworks/rspec'
 require 'shoulda-matchers'
 require 'capybara/rspec'
 require 'site_prism'
-
-unless ENV['SKIP_SIMPLECOV']
-  require 'simplecov'
-  SimpleCov.start 'rails' do
-    add_filter '/gem/'
-    add_filter '.bundle'
-  end
-  SimpleCov.minimum_coverage 50
-end
 
 Capybara.register_driver :poltergeist_silent do |app|
   # Redirect phantomjs log output to a dummy StringIO to ignore it


### PR DESCRIPTION
SimpleCov is causing issues with the test suite, not to mention coverage
isn't that great to begin with, and the various byebug gems
on top of pry aren't necessary.