### PR TITLE
Mailchimp tags MVP; archive subscribers

### DIFF
--- a/app/interactors/update_profile.rb
+++ b/app/interactors/update_profile.rb
@@ -51,13 +51,19 @@ class UpdateProfile
       person.email,
       @email_before_update,
       person.given_name,
-      person.surname
+      person.surname,
+      mailchimp_tags
     )
   end
 
   def touch_person_last_edited_or_confirmed_at
     # We don't mind not running validations on touching this attribute - this call should not fail
     person.touch(:last_edited_or_confirmed_at) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def mailchimp_tags
+    # TODO: This is an MVP and needs to move into a more appropriate place
+    ['pf_imported'] + person.building.select(&:present?).map { |building| "pf_building_#{building}" }
   end
 
   def person

--- a/app/services/mailchimp.rb
+++ b/app/services/mailchimp.rb
@@ -8,28 +8,45 @@ class Mailchimp
   def create_or_update_subscriber(email, merge_fields: {})
     # Upsert the subscriber details because there may or may not be an existing subscriber
     # for any given email address (c.f. #deactivate_subscriber)
-    upsert_member(email, email_address: email, status: 'subscribed', merge_fields: merge_fields)
+    body = {
+      email_address: email,
+      status: 'subscribed',
+      merge_fields: merge_fields
+    }
+    member_for(email).upsert(body: body)
+  end
+
+  def set_subscriber_tags(email, tags: [])
+    # The Mailchimp API does not allow us to set a subscriber's tags to a specific set of tags.
+    # We need to explicitly set all tags we want to remove to `inactive` instead of just leaving
+    # them out, so this requires us to figure out what existing tags a user has.
+    current_tags = member_for(email).retrieve.body['tags'].map { |tag| tag['name'] }
+
+    inactive_tags = current_tags
+                    .reject { |tag| tags.include?(tag) }
+                    .map { |tag| { name: tag, status: 'inactive' } }
+    active_tags = tags.map { |tag| { name: tag, status: 'active' } }
+
+    member_for(email).tags.create(body: { tags: inactive_tags + active_tags })
   end
 
   def deactivate_subscriber(email)
-    # Once a subscriber is deleted from Mailchimp, the same email can *never* be used on that
-    # list again. Therefore, we set the subscriber status for that email to "cleaned" instead
-    # so they are no longer included in campaigns, and if that email comes back into existence
-    # one day it can be upserted to "subscribed" again.
-    upsert_member(email, status: 'cleaned')
+    # Mailchimp has two kinds of delete; this is a "soft" delete which doesn't actually delete the
+    # subscriber, but moves them to the "archived" section of the audience. Subscribers that have
+    # been archived in this way can be recreated in the future.
+    member_for(email).delete
   end
 
   private
 
   attr_reader :mailchimp_client
 
-  def upsert_member(email, options)
+  def member_for(email)
     md5_of_lowercase_email = Digest::MD5.hexdigest(email.downcase)
 
     mailchimp_client
       .lists(list_id)
       .members(md5_of_lowercase_email)
-      .upsert(body: options)
   end
 
   def list_id

--- a/app/workers/remove_person_from_mailing_list_worker.rb
+++ b/app/workers/remove_person_from_mailing_list_worker.rb
@@ -3,7 +3,11 @@
 class RemovePersonFromMailingListWorker
   include Sidekiq::Worker
 
-  def perform(email, mailchimp_service = Mailchimp.new)
-    mailchimp_service.deactivate_subscriber(email)
+  def initialize(mailchimp_service: Mailchimp.new)
+    @mailchimp_service = mailchimp_service
+  end
+
+  def perform(email)
+    @mailchimp_service.deactivate_subscriber(email)
   end
 end

--- a/app/workers/update_person_on_mailing_list_worker.rb
+++ b/app/workers/update_person_on_mailing_list_worker.rb
@@ -3,13 +3,22 @@
 class UpdatePersonOnMailingListWorker
   include Sidekiq::Worker
 
-  def perform(email, previous_email, first_name, last_name, mailchimp_service = Mailchimp.new)
-    # Only deactivate previous subscriber if there is a previous email and it has changed
-    mailchimp_service.deactivate_subscriber(previous_email) if previous_email.present? && email != previous_email
+  def initialize(mailchimp_service: Mailchimp.new)
+    @mailchimp_service = mailchimp_service
+  end
 
-    mailchimp_service.create_or_update_subscriber(
+  def perform(email, previous_email, first_name, last_name, tags)
+    # Only deactivate previous subscriber if there is a previous email and it has changed
+    begin
+      @mailchimp_service.deactivate_subscriber(previous_email) if previous_email.present? && email != previous_email
+    rescue Gibbon::MailChimpError
+      # Don't fail if the previous email didn't exist
+    end
+
+    @mailchimp_service.create_or_update_subscriber(
       email,
       merge_fields: { FNAME: first_name, LNAME: last_name }
     )
+    @mailchimp_service.set_subscriber_tags(email, tags: tags)
   end
 end

--- a/spec/interactors/update_profile_spec.rb
+++ b/spec/interactors/update_profile_spec.rb
@@ -9,6 +9,7 @@ describe UpdateProfile do
       name: 'Per Son',
       given_name: 'Per',
       surname: 'Son',
+      building: ['', 'skyscraper', 'airport'],
       assign_attributes: true,
       save!: true,
       valid?: valid,
@@ -80,7 +81,8 @@ describe UpdateProfile do
           'person@example.com',
           'person@gov.uk',
           'Per',
-          'Son'
+          'Son',
+          %w[pf_imported pf_building_skyscraper pf_building_airport]
         )
       end
 

--- a/spec/workers/remove_person_from_mailing_list_worker_spec.rb
+++ b/spec/workers/remove_person_from_mailing_list_worker_spec.rb
@@ -6,7 +6,7 @@ describe RemovePersonFromMailingListWorker do
   let(:mailchimp_service) { instance_double(Mailchimp, deactivate_subscriber: true) }
 
   describe '#perform' do
-    subject! { described_class.new.perform('bye.bye@trade.gov.uk', mailchimp_service) }
+    subject! { described_class.new(mailchimp_service: mailchimp_service).perform('bye.bye@trade.gov.uk') }
 
     context 'when a previous email is given' do
       it 'deactivates the subscribed' do

--- a/spec/workers/update_person_on_mailing_list_worker_spec.rb
+++ b/spec/workers/update_person_on_mailing_list_worker_spec.rb
@@ -3,21 +3,23 @@
 require 'rails_helper'
 
 describe UpdatePersonOnMailingListWorker do
-  let(:mailchimp_service) { instance_double(Mailchimp, deactivate_subscriber: true, create_or_update_subscriber: true) }
+  let(:mailchimp_service) { instance_double(Mailchimp, deactivate_subscriber: true, create_or_update_subscriber: true, set_subscriber_tags: true) }
 
   describe '#perform' do
-    subject! { described_class.new.perform('per.son@trade.gov.uk', previous_email, 'Per', 'Son', mailchimp_service) }
+    subject! { described_class.new(mailchimp_service: mailchimp_service).perform('per.son@trade.gov.uk', previous_email, 'Per', 'Son', %w[tag1 tag2]) }
 
-    context 'when no previous email is given' do
-      let(:previous_email) { nil }
+    let(:previous_email) { nil }
 
-      it 'creates/updates the new email' do
-        expect(mailchimp_service).not_to have_received(:deactivate_subscriber)
-        expect(mailchimp_service).to have_received(:create_or_update_subscriber).with(
-          'per.son@trade.gov.uk',
-          merge_fields: { FNAME: 'Per', LNAME: 'Son' }
-        )
-      end
+    it 'sets tags for the user' do
+      expect(mailchimp_service).to have_received(:set_subscriber_tags).with('per.son@trade.gov.uk', tags: %w[tag1 tag2])
+    end
+
+    it 'creates/updates the new email' do
+      expect(mailchimp_service).not_to have_received(:deactivate_subscriber)
+      expect(mailchimp_service).to have_received(:create_or_update_subscriber).with(
+        'per.son@trade.gov.uk',
+        merge_fields: { FNAME: 'Per', LNAME: 'Son' }
+      )
     end
 
     context 'when a previous email is given' do


### PR DESCRIPTION
- Archive subscribers instead of setting status to cleaned
- Add ability to set tags in Mailchimp service
- Push basic building tags into Mailchimp
- Refactor DI in workers