### PR TITLE
Refactor mailing list updates into separate interactor

### DIFF
--- a/app/interactors/update_person_on_mailing_list.rb
+++ b/app/interactors/update_person_on_mailing_list.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class UpdatePersonOnMailingList
+  include Interactor
+
+  def call
+    return unless Rails.configuration.mailing_list_integration_enabled
+
+    UpdatePersonOnMailingListWorker.perform_async(
+      person.email,
+      context.previous_email,
+      person.given_name,
+      person.surname,
+      mailchimp_tags
+    )
+  end
+
+  private
+
+  def person
+    context.person
+  end
+
+  def mailchimp_tags
+    ['pf_imported'] + person.building.select(&:present?).map { |building| "pf_building_#{building}" }
+  end
+end

--- a/app/interactors/update_profile.rb
+++ b/app/interactors/update_profile.rb
@@ -45,25 +45,12 @@ class UpdateProfile
   end
 
   def update_person_on_mailing_list
-    return unless Rails.configuration.mailing_list_integration_enabled
-
-    UpdatePersonOnMailingListWorker.perform_async(
-      person.email,
-      @email_before_update,
-      person.given_name,
-      person.surname,
-      mailchimp_tags
-    )
+    UpdatePersonOnMailingList.call(person: person, previous_email: @email_before_update)
   end
 
   def touch_person_last_edited_or_confirmed_at
     # We don't mind not running validations on touching this attribute - this call should not fail
     person.touch(:last_edited_or_confirmed_at) # rubocop:disable Rails/SkipsModelValidations
-  end
-
-  def mailchimp_tags
-    # TODO: This is an MVP and needs to move into a more appropriate place
-    ['pf_imported'] + person.building.select(&:present?).map { |building| "pf_building_#{building}" }
   end
 
   def person

--- a/spec/interactors/update_person_on_mailing_list_spec.rb
+++ b/spec/interactors/update_person_on_mailing_list_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UpdatePersonOnMailingList do
+  let(:person) { instance_double(Person, email: 'person@example.com', given_name: 'Per', surname: 'Son', building: ['', 'skyscraper', 'airport']) }
+  let(:mailing_list_integration_enabled) { true }
+
+  before do
+    allow(UpdatePersonOnMailingListWorker).to receive(:perform_async)
+    allow(Rails.configuration).to receive(:mailing_list_integration_enabled).and_return(mailing_list_integration_enabled)
+  end
+
+  describe '.call' do
+    subject!(:context) { described_class.call(person: person, previous_email: 'person@gov.uk') }
+
+    it 'succeeds' do
+      expect(context).to be_a_success
+    end
+
+    it 'queues an UpdatePersonOnMailingListWorker with the previous email' do
+      expect(UpdatePersonOnMailingListWorker).to have_received(:perform_async).with(
+        'person@example.com',
+        'person@gov.uk',
+        'Per',
+        'Son',
+        %w[pf_imported pf_building_skyscraper pf_building_airport]
+      )
+    end
+
+    context 'when mailing list integration is disabled' do
+      let(:mailing_list_integration_enabled) { false }
+
+      it 'does not queue an UpdatePersonOnMailingListWorker' do
+        expect(UpdatePersonOnMailingListWorker).not_to have_received(:perform_async)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to just call interactors in bulk for an initial
import of data, and divides responsibility a bit more cleanly.