### PR TITLE
Add ability to disable external integrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,14 +11,10 @@ DITSSO_CALLBACK_URL=http://localhost:3000/auth/ditsso_internal/callback
 # The host the application is running on
 #   REQUIRED - app will not start without this set
 APP_HOST=localhost
-#
+
 # Authorisation Token used by other applications to access People Finder API
 #   REQUIRED - app will not start without this set
 PROFILE_API_TOKEN=profile_api_token
-
-# GOV.UK Notify credentials
-#   REQUIRED - You can obtain test tokens from the GOV.UK Notify admin interface
-GOVUK_NOTIFY_API_KEY=
 
 # Database, Redis, and Elasticsearch URLs
 #   REQUIRED - but if you're running through Docker Compose these are set there
@@ -29,6 +25,14 @@ DATABASE_URL=
 TEST_DATABASE_URL=
 REDIS_CACHE_URL=
 REDIS_SIDEKIQ_URL=
+
+# Enable external integrations
+#   People Finder integrates with a number of external systems as part of the person management
+#   lifecycle. Some of those may offer sandbox environments and/or no-op API keys that can be used
+#   locally or in development, CI, and staging environments, but others don't. Setting this to false
+#   disables integrations entirely to remove the need to set API keys and possibly end up with test
+#   data being sent to live integrations.
+ENABLE_EXTERNAL_INTEGRATIONS=false
 
 # URL for Digital Workspace frontend app
 HOME_PAGE_URL=http://localhost:4000
@@ -52,8 +56,12 @@ ZD_USER=
 ZD_SERVICE_ID=
 ZD_SERVICE_NAME=
 
+# GOV.UK Notify credentials
+#   Used for sending notifications (emails) through the GOV.UK Notify platform
+#   You can obtain test tokens from the GOV.UK Notify admin interface
+GOVUK_NOTIFY_API_KEY=
+
 # Mailchimp credentials
 #   Used for syncing mailing list data
-#   Unset MAILCHIMP_API_KEY to disable Mailchimp integration (e.g. on dev/staging or local)
 MAILCHIMP_API_KEY=
-MAILCHIMP_LIST_ID=   
+MAILCHIMP_LIST_ID=

--- a/app/interactors/remove_person.rb
+++ b/app/interactors/remove_person.rb
@@ -16,10 +16,14 @@ class RemovePerson
   end
 
   def remove_person_from_mailing_list
+    return unless Rails.configuration.enable_external_integrations
+
     MailingLists::DeactivateSubscriberWorker.perform_async(person.email)
   end
 
   def send_notification_to_deleted_person
+    return unless Rails.configuration.enable_external_integrations
+
     notifier.deleted_profile(person.email, recipient_name: person.name)
   end
 

--- a/app/interactors/update_profile.rb
+++ b/app/interactors/update_profile.rb
@@ -34,6 +34,7 @@ class UpdateProfile
   end
 
   def notify_updated_person_if_appropriate
+    return unless Rails.configuration.enable_external_integrations
     return unless person.notify_of_change?(instigator)
 
     notifier.updated_profile(
@@ -45,8 +46,9 @@ class UpdateProfile
   end
 
   def update_person_on_mailing_list
-    MailingLists::DeactivateSubscriberWorker.perform_async(@email_before_update) if person.email != @email_before_update
+    return unless Rails.configuration.enable_external_integrations
 
+    MailingLists::DeactivateSubscriberWorker.perform_async(@email_before_update) if person.email != @email_before_update
     MailingLists::CreateOrUpdateSubscriberForPersonWorker.perform_async(person.id)
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,6 +55,8 @@ module Peoplefinder
     config.elastic_apm.active = false # Overridden in production config
 
     config.elastic_search_url = ENV['ES_URL'] # Overridden in production config
+    # Overridden in test config
+    config.enable_external_integrations = ActiveModel::Type::Boolean.new.cast(ENV['ENABLE_EXTERNAL_INTEGRATIONS'])
     config.google_analytics_tracking_id = ENV['GA_TRACKING_ID']
     config.govuk_notify_api_key = ENV['GOVUK_NOTIFY_API_KEY']
     config.home_page_url = ENV['HOME_PAGE_URL']

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,4 +10,5 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
   config.action_controller.allow_forgery_protection = false
   config.active_support.deprecation = :stderr
+  config.enable_external_integrations = false
 end

--- a/spec/interactors/remove_person_spec.rb
+++ b/spec/interactors/remove_person_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 describe RemovePerson do
   let(:person) { instance_double(Person, email: 'good@bye.com', name: 'Good Bye', destroy!: true) }
   let(:notifier) { instance_double(GovukNotify, deleted_profile: true) }
+  let(:enable_external_integrations) { true }
 
   before do
     allow(MailingLists::DeactivateSubscriberWorker).to receive(:perform_async)
+    allow(Rails.configuration).to receive(:enable_external_integrations).and_return(enable_external_integrations)
   end
 
   describe '.call' do
@@ -27,6 +29,18 @@ describe RemovePerson do
 
     it 'sends an email to the deleted person to let them know they have been deleted' do
       expect(notifier).to have_received(:deleted_profile).with('good@bye.com', recipient_name: 'Good Bye')
+    end
+
+    context 'when external integrations are disabled' do
+      let(:enable_external_integrations) { false }
+
+      it 'does not queue any mailing list workers' do
+        expect(MailingLists::DeactivateSubscriberWorker).not_to have_received(:perform_async)
+      end
+
+      it 'does not send any emails' do
+        expect(notifier).not_to have_received(:deleted_profile)
+      end
     end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Person, type: :model do
   context 'search' do
     it 'deletes indexes' do
       expect(described_class.__elasticsearch__).to receive(:delete_index!)
-        .with(index: /test(_\d)?_people/)
+        .with(index: /test_?\d?_people/)
       described_class.delete_indexes
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,15 +20,4 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   WebMock.disable_net_connect!(allow: 'elasticsearch:9200', allow_localhost: true)
-
-  # TODO: Mock this in a better way - the URL is an implementation detail of the Notify API
-  config.before do
-    WebMock.stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/email')
-           .to_return(status: 200, body: '{}')
-
-    WebMock.stub_request(:get, /api.mailchimp.com/).to_return(status: 200, body: '{"tags": []}')
-    WebMock.stub_request(:put, /api.mailchimp.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /api.mailchimp.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:delete, /api.mailchimp.com/).to_return(status: 200, body: '{}')
-  end
 end


### PR DESCRIPTION
People Finder integrates with a number of external systems as part of
the person management lifecycle. Some of those may offer sandbox
environments and/or no-op API keys that can be used locally or in
development, CI, and staging environments, but others don't.

This adds the ability to use an environment variable to enable/disable
integration with these systems to remove the need to set API keys and
possibly end up with test data being sent to live integrations.