### PR TITLE
Add Sidekiq Web UI

### DIFF
--- a/app/policies/admin/management_policy.rb
+++ b/app/policies/admin/management_policy.rb
@@ -15,5 +15,9 @@ module Admin
     def csv_extract_report?
       administrator?
     end
+
+    def sidekiq?
+      administrator?
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   root 'home#show', as: :home
 
@@ -56,6 +58,10 @@ Rails.application.routes.draw do
 
     resource :profile_extract, only: [:show]
     resource :team_extract, only: [:show]
+
+    constraints AdminRouteConstraint.new do
+      mount Sidekiq::Web => '/sidekiq'
+    end
   end
 
   get '/my/profile', to: 'home#my_profile'

--- a/lib/admin_route_constraint.rb
+++ b/lib/admin_route_constraint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Protect admin-restricted areas on the route layer level
+# Used for mounted Rack apps that we can't authorise on the controller layer
+class AdminRouteConstraint
+  def matches?(request)
+    current_user_id = request.session[ApplicationController::SESSION_KEY]
+    return false if current_user_id.blank?
+
+    current_user = Person.find(current_user_id)
+    Admin::ManagementPolicy.new(current_user, :management).sidekiq?
+  end
+end

--- a/spec/policies/admin/management_policy_spec.rb
+++ b/spec/policies/admin/management_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::ManagementPolicy, type: :policy do
   subject { described_class.new(user, nil) }
 
-  ACTIONS = %i[show csv_extract_report].freeze
+  ACTIONS = %i[show csv_extract_report sidekiq].freeze
 
   context 'for an administrator' do
     let(:user) { build_stubbed(:administrator) }


### PR DESCRIPTION
Useful for debugging purposes and job visibility.

- Add Sidekiq Web UI
- Add `AdminRouteConstraint` to allow for route-level access control to
  Sidekiq UI