### PR TITLE
Initial Data Workspace export API endpoint

### DIFF
--- a/app/controllers/api/v2/data_workspace_exports_controller.rb
+++ b/app/controllers/api/v2/data_workspace_exports_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api::V2
+  class DataWorkspaceExportsController < Api::ApplicationController
+    PER_PAGE = 100
+
+    def show
+      people = Person.page(page).per(PER_PAGE)
+      results = people.map { |person| DataWorkspacePersonSerializer.new(person) }
+      next_page = api_v2_data_workspace_export_url(page: people.next_page) unless people.last_page?
+
+      render json: { results: results, next: next_page }
+    end
+
+    private
+
+    def page
+      params[:page] || 1
+    end
+  end
+end

--- a/app/serializers/data_workspace_person_serializer.rb
+++ b/app/serializers/data_workspace_person_serializer.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class DataWorkspacePersonSerializer
+  PERSON_KEYS = %w[
+    email skype_name
+    works_monday works_tuesday works_wednesday works_thursday works_friday works_saturday works_sunday
+    location_in_building city country
+    language_fluent language_intermediate grade
+    created_at last_edited_or_confirmed_at
+  ].freeze
+
+  def initialize(person)
+    @person = person
+  end
+
+  def as_json(_options = {}) # rubocop:disable Metrics/MethodLength
+    person
+      .as_json
+      .slice(*PERSON_KEYS)
+      .merge(
+        people_finder_id: person.id,
+        staff_sso_id: person.ditsso_user_id,
+        full_name: person.name,
+        first_name: person.given_name,
+        last_name: person.surname,
+        primary_phone_number: primary_phone_number,
+        secondary_phone_number: secondary_phone_number,
+        location_other_uk: person.other_uk,
+        location_other_overseas: person.other_overseas,
+        place_of_work: person.formatted_buildings,
+        roles: person.memberships.map { |membership| "#{membership.role}; #{membership.group.name}" },
+        key_skills: person.formatted_key_skills,
+        learning_and_development: person.formatted_learning_and_development,
+        networks: person.formatted_networks,
+        professions: person.formatted_professions,
+        additional_responsibilities: person.formatted_additional_responsibilities,
+        manager_people_finder_id: person.line_manager_id,
+        completion_score: person.completion_score,
+        profile_url: profile_url
+      )
+      .stringify_keys
+  end
+
+  private
+
+  attr_reader :person
+
+  def primary_phone_number
+    ApplicationController.helpers.phone_number_with_country_code(
+      person.primary_phone_country,
+      person.primary_phone_number
+    )
+  end
+
+  def secondary_phone_number
+    ApplicationController.helpers.phone_number_with_country_code(
+      person.secondary_phone_country,
+      person.secondary_phone_number
+    )
+  end
+
+  def profile_url
+    Rails.application.routes.url_helpers.person_url(person)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
     namespace :v2 do
       resources :people, only: [:show]
+      resource :data_workspace_export, only: [:show]
     end
   end
 

--- a/spec/serializers/data_workspace_person_serializer_spec.rb
+++ b/spec/serializers/data_workspace_person_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DataWorkspacePersonSerializer do
+  subject { described_class.new(person) }
+
+  let(:person) { build_stubbed(:person) }
+
+  describe '#as_json' do
+    let(:json_hash) { subject.as_json }
+    let(:expected_keys) do
+      %w[
+        email skype_name works_monday works_tuesday works_wednesday works_thursday works_friday works_saturday
+        works_sunday location_in_building city country language_fluent language_intermediate grade created_at
+        last_edited_or_confirmed_at people_finder_id staff_sso_id full_name first_name last_name primary_phone_number
+        secondary_phone_number location_other_uk location_other_overseas place_of_work roles key_skills
+        learning_and_development networks professions additional_responsibilities manager_people_finder_id
+        completion_score profile_url
+      ]
+    end
+
+    it 'has the appropriate keys' do
+      expect(json_hash).to include(*expected_keys)
+    end
+  end
+end


### PR DESCRIPTION
This allows us to export the data currently included in the CSV extract
(and more) over an API instead.