### PR TITLE
Add Mailchimp tag for "One DIT" group

### DIFF
--- a/app/decorators/mailing_list_person_decorator.rb
+++ b/app/decorators/mailing_list_person_decorator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class MailingListPersonDecorator < SimpleDelegator
+  GROUP_ONE_DIT_DOMAINS = %w[
+    @trade.gov
+    @mobile.trade.gov.uk
+    @digital.trade.gov.uk
+    @fco.gov.uk
+    @ukexportfinance.gov.uk
+    @traderemedies.gov.uk
+    @dfid.gov.uk
+    @entrepreneurs.gov.uk
+  ].freeze
+
+  def merge_fields
+    {
+      FNAME: given_name,
+      LNAME: surname
+    }
+  end
+
+  def tags
+    ['pf_imported'] + building_tags + group_tags
+  end
+
+  private
+
+  def building_tags
+    building.select(&:present?).map { |building| "pf_building_#{building}" }
+  end
+
+  def group_tags
+    [].tap do |ary|
+      ary << 'group_onedit' if email.end_with?(*GROUP_ONE_DIT_DOMAINS)
+    end
+  end
+end

--- a/app/interactors/mailing_lists/create_or_update_subscriber_for_person.rb
+++ b/app/interactors/mailing_lists/create_or_update_subscriber_for_person.rb
@@ -12,26 +12,15 @@ module MailingLists
     private
 
     def create_or_update_subscriber
-      mailing_list_service.create_or_update_subscriber(person.email, merge_fields: merge_fields)
+      mailing_list_service.create_or_update_subscriber(person.email, merge_fields: person.merge_fields)
     end
 
     def set_subscriber_tags
-      mailing_list_service.set_subscriber_tags(person.email, tags: tags)
+      mailing_list_service.set_subscriber_tags(person.email, tags: person.tags)
     end
 
     def person
-      context.person
-    end
-
-    def merge_fields
-      {
-        FNAME: person.given_name,
-        LNAME: person.surname
-      }
-    end
-
-    def tags
-      ['pf_imported'] + person.building.select(&:present?).map { |building| "pf_building_#{building}" }
+      @person ||= MailingListPersonDecorator.new(context.person)
     end
 
     def mailing_list_service

--- a/spec/decorators/mailing_list_person_decorator_spec.rb
+++ b/spec/decorators/mailing_list_person_decorator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MailingListPersonDecorator do
+  subject { described_class.new(person) }
+
+  let(:person) { build_stubbed(:person, email: email, given_name: 'Mail', surname: 'Chimp', building: ['', 'skyscraper', 'airport']) }
+  let(:email) { 'mail@chimp.com' }
+
+  describe '#merge_fields' do
+    it 'returns the expected Mailchimp merge fields' do
+      expect(subject.merge_fields).to eq({ FNAME: 'Mail', LNAME: 'Chimp' })
+    end
+  end
+
+  describe '#tags' do
+    it 'returns the expected Mailchimp tags' do
+      expect(subject.tags).to contain_exactly('pf_imported', 'pf_building_skyscraper', 'pf_building_airport')
+    end
+
+    context 'when the person has an email address that should be included on the "main list"' do
+      let(:email) { 'a.b@digital.trade.gov.uk' }
+
+      it 'adds the appropriate tag' do
+        expect(subject.tags).to include('group_onedit')
+      end
+    end
+  end
+end

--- a/spec/interactors/mailing_lists/create_or_update_subscriber_for_person_spec.rb
+++ b/spec/interactors/mailing_lists/create_or_update_subscriber_for_person_spec.rb
@@ -3,8 +3,14 @@
 require 'rails_helper'
 
 describe MailingLists::CreateOrUpdateSubscriberForPerson do
-  let(:person) { instance_double(Person, email: 'mail@chimp.com', given_name: 'Mail', surname: 'Chimp', building: ['', 'skyscraper', 'airport']) }
+  let(:person) { instance_double(Person) }
+  let(:decorated_person) { double('decorated person', email: 'mail@chimp.com', tags: ['tag'], merge_fields: { 'merge' => 'field' }) }
+
   let(:mailing_list_service) { instance_double(MailingList, deactivate_subscriber: true, create_or_update_subscriber: true, set_subscriber_tags: true) }
+
+  before do
+    allow(MailingListPersonDecorator).to receive(:new).with(person).and_return(decorated_person)
+  end
 
   describe '.call' do
     subject!(:context) { described_class.call(person: person, mailing_list_service: mailing_list_service) }
@@ -12,10 +18,10 @@ describe MailingLists::CreateOrUpdateSubscriberForPerson do
     it 'creates/updates the subscriber and sets tags' do
       expect(mailing_list_service).to have_received(:create_or_update_subscriber).with(
         'mail@chimp.com',
-        merge_fields: { FNAME: 'Mail', LNAME: 'Chimp' }
+        merge_fields: { 'merge' => 'field' }
       )
 
-      expect(mailing_list_service).to have_received(:set_subscriber_tags).with('mail@chimp.com', tags: %w[pf_imported pf_building_skyscraper pf_building_airport])
+      expect(mailing_list_service).to have_received(:set_subscriber_tags).with('mail@chimp.com', tags: ['tag'])
     end
   end
 end


### PR DESCRIPTION
- Refactor tag/merge field logic from Mailchimp interactor into
  decorator
- Add list of domains considered part of group and add tag
  accordingly