### PR TITLE
Tune Sidekiq to resolve memory management issues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec rake db:migrate && bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq
+worker: MALLOC_ARENA_MAX=2 bundle exec sidekiq -c 5


### PR DESCRIPTION
We are seeing issues in production with Sidekiq workers being killed
frequently due to running out of memory. This attempts to tweak memory
consumption of workers as follows:

- Reduce threading (from default 25 to explicit 5)
- Set `MALLOC_ARENA_MAX` to 2 to reduce glibc memory arena count

(c.f. https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat)