### PR TITLE
Remove phone number country code handling

### DIFF
--- a/app/controllers/admin/profile_extracts_controller.rb
+++ b/app/controllers/admin/profile_extracts_controller.rb
@@ -37,8 +37,7 @@ module Admin
         City Country JobTitle
         LastLogin ProfileCompletionScore
         TeamId TeamName
-        PrimaryPhoneNumber
-        SecondaryPhoneNumber
+        PrimaryPhoneNumber SecondaryPhoneNumber
         LineManagerPeopleFinderId
       ]
     end
@@ -53,14 +52,7 @@ module Admin
         person.city, person.country_name, membership.try(:role),
         person.last_login_at, person.completion_score,
         membership.try(:group).try(:id), membership.try(:group).try(:name),
-        phone_number_with_country_code(
-          person.primary_phone_country,
-          person.primary_phone_number
-        ),
-        phone_number_with_country_code(
-          person.secondary_phone_country,
-          person.secondary_phone_number
-        ),
+        person.primary_phone_number, person.secondary_phone_number,
         person.line_manager_id
       ]
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,18 +78,6 @@ module ApplicationHelper
     tag.a(**options.merge(href: "tel:#{digits}")) { telno }
   end
 
-  def phone_number_with_country_code(country, phone_number)
-    if country.present? && phone_number.present?
-      "+#{country.country_code} #{phone_number.delete_prefix('0')}"
-    else
-      phone_number
-    end
-  end
-
-  def call_to_with_country_code(country, phone_number, options = {})
-    call_to(phone_number_with_country_code(country, phone_number), options)
-  end
-
   def role_translate(subject, key, options = {})
     if subject == current_user
       subkey = 'mine'

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -167,14 +167,6 @@ class Person < ApplicationRecord
     [base_phone].compact
   end
 
-  def primary_phone_country
-    primary_phone_country_code.present? ? ISO3166::Country.new(primary_phone_country_code) : nil
-  end
-
-  def secondary_phone_country
-    secondary_phone_country_code.present? ? ISO3166::Country.new(secondary_phone_country_code) : nil
-  end
-
   def notify_of_change?(person_responsible)
     person_responsible.try(:email) != email
   end

--- a/app/serializers/person_data_workspace_serializer.rb
+++ b/app/serializers/person_data_workspace_serializer.rb
@@ -24,8 +24,8 @@ class PersonDataWorkspaceSerializer
         full_name: person.name,
         first_name: person.given_name,
         last_name: person.surname,
-        primary_phone_number: primary_phone_number,
-        secondary_phone_number: secondary_phone_number,
+        primary_phone_number: person.primary_phone_number,
+        secondary_phone_number: person.secondary_phone_number,
         formatted_location: person.location,
         location_other_uk: person.other_uk,
         location_other_overseas: person.other_overseas,
@@ -61,20 +61,6 @@ class PersonDataWorkspaceSerializer
   private
 
   attr_reader :person
-
-  def primary_phone_number
-    ApplicationController.helpers.phone_number_with_country_code(
-      person.primary_phone_country,
-      person.primary_phone_number
-    )
-  end
-
-  def secondary_phone_number
-    ApplicationController.helpers.phone_number_with_country_code(
-      person.secondary_phone_country,
-      person.secondary_phone_number
-    )
-  end
 
   def profile_url
     Rails.application.routes.url_helpers.person_url(person)

--- a/config/initializers/country_select.rb
+++ b/config/initializers/country_select.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-CountrySelect::FORMATS[:with_dialling_code] = lambda do |country|
-  "#{country.name} (+#{country.country_code})"
-end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -80,39 +80,6 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#phone_number_with_country_code' do
-    let(:country) { ISO3166::Country.new('GB') }
-    let(:phone_number) { '1234 56789' }
-
-    it 'returns a phone number prepended with the country code given a country' do
-      expect(phone_number_with_country_code(country, phone_number)).to eq('+44 1234 56789')
-    end
-
-    it 'returns only the phone number when no country is provided' do
-      expect(phone_number_with_country_code(nil, phone_number)).to eq('1234 56789')
-    end
-
-    context 'when the phone number starts with a zero' do
-      let(:phone_number) { '01234 56789' }
-
-      it 'returns a formatted phone number with the zero removed' do
-        expect(phone_number_with_country_code(country, phone_number)).to eq('+44 1234 56789')
-      end
-    end
-  end
-
-  describe '#call_to_with_country_code' do
-    let(:country) { ISO3166::Country.new('GB') }
-    let(:phone_number) { '1234 56789' }
-
-    it 'returns a phone number prepended with the country code with a tel href' do
-      expect(self).to receive(:phone_number_with_country_code).with(country, phone_number).and_return('+44 12345')
-      expect(self).to receive(:call_to).with('+44 12345', {}).and_return('tel:4412345')
-
-      expect(call_to_with_country_code(country, phone_number)).to eq('tel:4412345')
-    end
-  end
-
   describe '#role_translate' do
     let(:current_user) { build(:person) }
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -30,13 +30,11 @@ RSpec.describe Person, type: :model do
     subject do
       build(
         :person,
-        primary_phone_number: phone_number,
-        primary_phone_country_code: country_code
+        primary_phone_number: phone_number
       )
     end
 
     let(:phone_number) { '0118 999-881 999 119 (725) ext. 3' }
-    let(:country_code) { 'GB' }
 
     it 'returns the expected variatons' do
       expect(subject.phone_number_variations).to eq(
@@ -44,18 +42,6 @@ RSpec.describe Person, type: :model do
           01189998819991197253
         ]
       )
-    end
-
-    context 'when no country is provided' do
-      let(:country_code) { nil }
-
-      it 'returns only the country code-less variation' do
-        expect(subject.phone_number_variations).to eq(
-          %w[
-            01189998819991197253
-          ]
-        )
-      end
     end
 
     context 'when the phone number does not start with "0"' do
@@ -367,20 +353,6 @@ RSpec.describe Person, type: :model do
       it 'returns nil' do
         expect(person.profile_image).to be_nil
       end
-    end
-  end
-
-  describe '#primary_phone_country' do
-    it 'returns an instance of ISO3166::Country when a value is present' do
-      person.primary_phone_country_code = 'GB'
-
-      expect(person.primary_phone_country).to eq(ISO3166::Country.new('GB'))
-    end
-
-    it 'returns nil when a value is not present' do
-      person.primary_phone_country_code = nil
-
-      expect(person.primary_phone_country).to be_nil
     end
   end
 


### PR DESCRIPTION
This still remained in a handful of places and can now be removed.