### PR TITLE
Allow users to specify separate contact email

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -109,7 +109,7 @@ class PeopleController < ApplicationController
   def person_params_list
     %i[
       given_name surname location_in_building city country primary_phone_number
-      skype_name secondary_phone_number email
+      skype_name secondary_phone_number email contact_email
       language_intermediate language_fluent previous_positions grade
       other_uk other_overseas pronouns other_key_skills other_learning_and_development
       other_additional_responsibilities line_manager_id line_manager_not_required

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -41,7 +41,7 @@ module Searchable
     } do
       mapping do
         indexes :name, fielddata: true, type: 'text'
-        indexes :email, type: 'keyword'
+        indexes :contact_email_or_email, type: 'keyword'
       end
     end
   end

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -129,7 +129,7 @@ class PersonSearch
       bool: {
         must: {
           match: {
-            email: @email_query
+            contact_email_or_email: @email_query
           }
         }
       }
@@ -224,7 +224,7 @@ class PersonSearch
     {
       name: {},
       role_and_group: {},
-      email: {},
+      contact_email_or_email: {},
       languages: {},
       formatted_key_skills: {},
       formatted_learning_and_development: {}

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class EmailAddressValidator < ActiveModel::EachValidator
+  # Nowhere near exhaustive list of "insecure" providers, but covers our particular problem cases
+  DISALLOWED_EMAIL_DOMAINS = %w[
+    aol.com btinternet.com fcowebmail.gov.uk gmail.com hotmail.com hotmail.co.uk outlook.com yahoo.com ymail.com
+  ].freeze
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    name = I18n.t("helpers.label.#{record.model_name.i18n_key}.#{attribute}")
+
+    record.errors.add(attribute, "#{name} is not a valid email address") unless value.match?(URI::MailTo::EMAIL_REGEXP)
+
+    domain = value.split('@').last&.downcase
+    return unless DISALLOWED_EMAIL_DOMAINS.include?(domain)
+
+    record.errors.add(attribute, "#{name} is not acceptable (#{domain} addresses are not allowed)")
+  end
+end

--- a/app/views/people/edit.html.slim
+++ b/app/views/people/edit.html.slim
@@ -5,7 +5,6 @@
 
 .ws-profile-edit
   = form_for(person, builder: PeopleFinderFormBuilder) do |f|
-    = f.submit 'Save', name: 'hidden-commit', class: 'ws-profile-edit__hidden-submit'
     .govuk-grid-row
       .govuk-grid-column-full
         h1.govuk-heading-l Edit profile
@@ -19,6 +18,7 @@
         = f.govuk_text_field :given_name, width: 'one-half'
         = f.govuk_text_field :surname, width: 'one-half'
 
+
         = f.additional_fields_details 'Add pronouns (optional)' do
           = f.govuk_text_field :pronouns, width: 'one-half', label: { text: self_or_other_label(person, :pronouns) }
 
@@ -26,9 +26,41 @@
 
     .govuk-grid-row
       .govuk-grid-column-full
-        h2.govuk-heading-m Contact details
+        h2.govuk-heading-m Email addresses
 
-        = f.govuk_email_field :email, width: 'one-half'
+        = f.govuk_phone_field :email, width: 'one-half'
+
+        .govuk-warning-text class='govuk-!-margin-bottom-0'
+          span.govuk-warning-text__icon aria-hidden='true' !
+          strong.govuk-warning-text__text
+            span.govuk-warning-text__assistive Warning
+            ' Do not enter any of the following as your main work email address:
+            ul.list.list-bullet.govuk-body
+              li a shared email address, for example, a Private Office or jobshare mailbox
+              li a secondary work email address, for example, a trade.gov.uk email address if you are employed by FCO at post
+              li an alternative work email address that is not safe for official information, for example, fcowebmail.gov.uk
+              li a personal email address, for example, Gmail
+
+        - if person.contact_email.present?
+          = f.govuk_email_field :contact_email, width: 'one-half'
+        - else
+          div data-controller='person-additional-emails'
+            p.govuk-body.govuk-inset-text class='govuk-!-margin-top-0' data-target='person-additional-emails.explanationPanel'
+              ' If you want to show a different email address on your profile for your colleagues to contact you on instead,
+              ' for example a jobshare mailbox or your Private Office address, you can
+              a.govuk-link.govuk-link--muted href='#' data-action='person-additional-emails#reveal' add a contact email address
+              | .
+            .ws-profile-edit__additional-email--hidden data-target='person-additional-emails.fieldContainer'
+              = f.govuk_email_field :contact_email, width: 'one-half', data: { target: 'person-additional-emails.field' }
+
+
+    .govuk-grid-row
+      .govuk-grid-column-full
+        hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+
+    .govuk-grid-row
+      .govuk-grid-column-full
+        h2.govuk-heading-m Contact details
         = f.govuk_phone_field :primary_phone_number, width: 'one-half'
 
         = f.additional_fields_details 'Add alternative contact number (optional)' do

--- a/app/views/people/show.html.slim
+++ b/app/views/people/show.html.slim
@@ -22,7 +22,7 @@
               | This profile was last edited #{time_ago_in_words(person.last_edited_or_confirmed_at)} ago.
       dl.ws-profile__primary-contact-list
         dt.govuk-visually-hidden Preferred contact email
-        dd.ws-profile__primary-contact-item = mail_to person.email, person.email, class: 'govuk-link'
+        dd.ws-profile__primary-contact-item = mail_to person.contact_email_or_email, person.contact_email_or_email, class: 'govuk-link'
         dt.govuk-visually-hidden Preferred contact number
         dd.ws-profile__primary-contact-item = call_to(person.primary_phone_number, class: 'govuk-link')
       ul.ws-profile__roles
@@ -57,7 +57,7 @@
         = profile_field(person, :other_uk)
         = profile_field(person, :other_overseas)
         = profile_field(person, :email) do
-          = mail_to person.email, person.email, class: 'govuk-link'
+          = mail_to person.contact_email_or_email, person.contact_email_or_email, class: 'govuk-link'
         = profile_field(person, :primary_phone_number) do
           = call_to person.primary_phone_number, class: 'govuk-link'
         = profile_field(person, :secondary_phone_number) do

--- a/app/views/search/_person.html.haml
+++ b/app/views/search/_person.html.haml
@@ -23,7 +23,7 @@
           %li.cb-person-phone
             = call_to(person.phone)
           %li.cb-person-email
-            = mail_to(person.email, es_highlighter(hit, person, :email))
+            = mail_to(person.contact_email_or_email, es_highlighter(hit, person, :contact_email_or_email))
 
           - if person.languages.present?
             %li.cb-person-languages.core-16

--- a/app/webpacker/javascript/controllers/person_additional_emails_controller.js
+++ b/app/webpacker/javascript/controllers/person_additional_emails_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  static targets = ['explanationPanel', 'field', 'fieldContainer'];
+
+  reveal(event) {
+    this.explanationPanelTarget.classList.add('ws-profile-edit__additional-email--hidden');
+    this.fieldContainerTarget.classList.remove('ws-profile-edit__additional-email--hidden');
+
+    this.fieldTarget.focus();
+
+    event.preventDefault();
+  }
+}

--- a/app/webpacker/stylesheets/components/profile_edit.scss
+++ b/app/webpacker/stylesheets/components/profile_edit.scss
@@ -1,6 +1,5 @@
-.ws-profile-edit__hidden-submit {
-  position: absolute;
-  left: -1000%;
+.ws-profile-edit__additional-email--hidden {
+  display: none;
 }
 
 .ws-profile-edit__manager {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
         given_name: First name
         surname: Last name
         email: Main work email address
+        contact_email: Contact email address
         primary_phone_number: Preferred contact number
         secondary_phone_number: Alternative contact number
         city: Town, city or region
@@ -111,12 +112,8 @@ en:
         acronym: A shorter version of the team name (e.g. DDaT)
         description: What does this team do? You can use basic Markdown to add lists or links.
       person:
-        email_html: |
-          Do not use:
-          <ul class="list list-bullet">
-            <li>an alternative work email address that is not safe for official information, for example, FCOWebmail.gov.uk</li>
-            <li>a personal email address, for example, Gmail</li>
-          </ul>
+        email: Enter your own official work email address provided by the organisation you are directly employed by or contracted to
+        contact_email: Enter the email address your colleagues should contact you on, for example, a jobshare or Private Office mailbox. This will be shown on your profile instead of your main work email address. Do not enter a personal email address, or a work email address that is not safe for official information.
         primary_phone_number: Enter your preferred contact telephone number. Include your country dialling code.
         secondary_phone_number: Enter an alternative contact telephone number. Include your country dialling code.
         building: Select all that apply

--- a/db/migrate/20200821103046_add_more_emails_to_people.rb
+++ b/db/migrate/20200821103046_add_more_emails_to_people.rb
@@ -1,0 +1,5 @@
+class AddMoreEmailsToPeople < ActiveRecord::Migration[6.0]
+  def change
+    add_column :people, :contact_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_090127) do
+ActiveRecord::Schema.define(version: 2020_08_21_103046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,8 @@ ActiveRecord::Schema.define(version: 2020_08_19_090127) do
     t.boolean "role_people_editor", default: false
     t.boolean "role_groups_editor", default: false
     t.datetime "last_edited_or_confirmed_at"
+    t.string "mailing_lists_email"
+    t.string "contact_email"
     t.index ["slug"], name: "index_people_on_slug", unique: true
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -26,6 +26,28 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe '#contact_email_or_email' do
+    subject { create(:person, email: email, contact_email: contact_email) }
+
+    context 'when contact_email is given' do
+      let(:email) { 'private@example.com' }
+      let(:contact_email) { 'public@example.com' }
+
+      it 'returns the contact_email' do
+        expect(subject.contact_email_or_email).to eq('public@example.com')
+      end
+    end
+
+    context 'when contact_email is not given' do
+      let(:email) { 'email@example.com' }
+      let(:contact_email) { '' }
+
+      it 'returns the email' do
+        expect(subject.contact_email_or_email).to eq('email@example.com')
+      end
+    end
+  end
+
   describe '#phone_number_variations' do
     subject do
       build(
@@ -69,13 +91,13 @@ RSpec.describe Person, type: :model do
     it 'raises an invalid format error if present but invalid' do
       person = build :person, email: 'sdsdsdsds'
       expect(person.save).to be false
-      expect(person.errors[:email]).to eq(['is invalid'])
+      expect(person.errors[:email]).to eq(['Main work email address is not a valid email address'])
     end
 
     it 'has an error if the domain is disallowed' do
       person = build(:person, email: 'jim@Gmail.com')
       expect(person.save).to be false
-      expect(person.errors[:email]).to eq(['is not acceptable (gmail.com addresses are not allowed)'])
+      expect(person.errors[:email]).to eq(['Main work email address is not acceptable (gmail.com addresses are not allowed)'])
     end
 
     it 'is converted to lower case' do


### PR DESCRIPTION
Some users do not want their colleagues to contact them on their main
official email address. This adds the ability to separately specify
an official individual email address, and an optional contact email
address, which if specified replaces the address shown on the user's
profile.