### PR TITLE
Tweak search logic

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -11,7 +11,7 @@ class Search
   attr_accessor :query, :filters
 
   def initialize(attributes = nil)
-    attributes[:query] = attributes[:query].gsub(/[^\w\-_@]/, ' ')
+    attributes[:query] = attributes[:query].gsub(/[^\w\-_@']/, ' ')
     attributes[:filters] ||= []
 
     super
@@ -109,6 +109,7 @@ class Search
       highlight: {
         pre_tags: ES_PRE_TAGS,
         post_tags: ES_POST_TAGS,
+        number_of_fragments: 0, # always return entire field in highlight
         fields: {
           name: {},
           role_and_group: {},


### PR DESCRIPTION
- Add apostrophe to acceptable search term characters
- Set `number_of_fragments` to 0 for highlights (avoids highlight only
  returning partial names when name contains full stop character)