### PR TITLE
Add simple HR data upload functionality

### DIFF
--- a/app/controllers/admin/hr_data_imports_controller.rb
+++ b/app/controllers/admin/hr_data_imports_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Admin
+  class HrDataImportsController < ApplicationController
+    before_action :authorize_user
+
+    breadcrumb 'admin.management', :admin_home_path, match: :exact
+    breadcrumb 'admin.hr_data_import', :new_admin_hr_data_import
+
+    def new; end
+
+    def create
+      if csv_file.blank?
+        flash.now[:error] = 'No file uploaded'
+
+        render :new
+        return
+      end
+
+      result = ImportHrData.call(csv_file: csv_file)
+
+      if result.success?
+        flash[:notice] = 'Upload successful - profiles will be updated in the background'
+        redirect_to admin_home_path
+      else
+        flash.now[:error] = result.error
+        render :new
+      end
+    end
+
+    private
+
+    def csv_file
+      params[:csv_file]
+    end
+
+    def authorize_user
+      authorize :'Admin::Management', :hr_data_imports?
+    end
+  end
+end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -107,7 +107,7 @@ class PeopleController < ApplicationController
     %i[
       given_name surname location_in_building city country primary_phone_number
       skype_name secondary_phone_number email contact_email
-      language_intermediate language_fluent previous_positions grade
+      language_intermediate language_fluent previous_positions
       other_uk other_overseas pronouns other_key_skills other_learning_and_development
       other_additional_responsibilities line_manager_id line_manager_not_required
     ] + [
@@ -130,6 +130,6 @@ class PeopleController < ApplicationController
     # Parameters that can only be updated by administrators, not regular users
     return [] unless current_user.role_administrator?
 
-    %i[role_administrator role_people_editor role_groups_editor ditsso_user_id]
+    %i[role_administrator role_people_editor role_groups_editor ditsso_user_id grade]
   end
 end

--- a/app/decorators/mailing_list_person_decorator.rb
+++ b/app/decorators/mailing_list_person_decorator.rb
@@ -16,7 +16,8 @@ class MailingListPersonDecorator < SimpleDelegator
     {
       FNAME: given_name,
       LNAME: surname,
-      PF_COUNTRY: country
+      PF_COUNTRY: country,
+      GRADE: grade.to_s
     }
   end
 

--- a/app/interactors/import_hr_data.rb
+++ b/app/interactors/import_hr_data.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+class ImportHrData
+  include Interactor
+
+  def call
+    check_data_coherence
+    import_data
+  end
+
+  private
+
+  def check_data_coherence
+    first_row = HrDataRow.from_csv_row(csv.second)
+    return if first_row.valid?
+
+    context.fail!(error: "Coherence check on first row of data failed: #{first_row.errors.full_messages.join(', ')}")
+  end
+
+  def import_data
+    csv.drop(1).each do |row|
+      UpdatePersonFromHrImportWorker.perform_async(row)
+    end
+  end
+
+  def csv
+    @csv = CSV.read(context.csv_file.path)
+  rescue CSV::MalformedCSVError
+    context.fail!(error: 'Could not read uploaded file - is it definitely in CSV format?')
+  end
+end

--- a/app/models/hr_data_row.rb
+++ b/app/models/hr_data_row.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class HrDataRow
+  EXPECTED_NUM_COLUMNS = 6
+  EMAIL_COLUMN = 4
+  GRADE_COLUMN = 3
+
+  GRADE_MAPPINGS = {
+    'unspecified' => nil,
+    'SCS4 Level' => :scs_4,
+    'SCS3 Level' => :scs_3,
+    'SCS2 Level' => :scs_2,
+    'SCS1 Level' => :scs_1,
+    'G6 Level' => :grade_6,
+    'G7 Level' => :grade_7,
+    'SEO Level' => :senior_executive_officer,
+    'HEO Level' => :higher_executive_officer,
+    'EO Level' => :executive_officer,
+    'AO Level' => :admin_officer,
+    'AA Level' => :admin_assistant,
+    'Faststream Level' => :fast_stream,
+    'Intern' => :intern
+  }.freeze
+
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Validations::Callbacks
+  include Sanitizable
+
+  attr_accessor :email, :grade
+
+  validates :email, presence: true, email_address: true
+  validate :grade_is_correct_format
+
+  sanitize_fields :email, strip: true, downcase: true
+
+  def self.from_csv_row(row)
+    new(email: row[EMAIL_COLUMN], grade: row[GRADE_COLUMN])
+  end
+
+  def mapped_grade
+    GRADE_MAPPINGS[grade]
+  end
+
+  private
+
+  def grade_is_correct_format
+    errors.add(:grade, "is an unexpected value ('#{grade}')") if GRADE_MAPPINGS.keys.exclude?(grade)
+  end
+end

--- a/app/policies/admin/management_policy.rb
+++ b/app/policies/admin/management_policy.rb
@@ -19,5 +19,9 @@ module Admin
     def sidekiq?
       administrator?
     end
+
+    def hr_data_imports?
+      administrator?
+    end
   end
 end

--- a/app/views/admin/hr_data_imports/new.html.slim
+++ b/app/views/admin/hr_data_imports/new.html.slim
@@ -1,0 +1,33 @@
+h1.govuk-heading-l Import HR data
+
+p.govuk-body
+  ' You can import a CSV file of HR data into People Finder. This will be matched to existing users based on their
+  ' (lower-cased) email address.
+
+.govuk-inset-text
+  p.govuk-body Currently only the following fields will be updated in case of a match:
+  ul.govuk-list.govuk-list--bullet
+    li Grade
+  p.govuk-body All other data in the CSV will be ignored.
+
+h3.govuk-heading-s The file must:
+ul.govuk-list.govuk-list--bullet
+  li Be a CSV file (not Excel or any other file type)
+  li Have a header row (the first row will be ignored during import)
+  li Contain exactly six columns in this order:
+  ul.govuk-list.govuk-list--number
+    li Staff number (SE-No)
+    li First name
+    li Last name
+    li Grade
+    li Email
+    li Region
+
+hr.govuk-section-break.govuk-section-break--m.govuk-section-break--visible
+
+= form_with(url: admin_hr_data_import_path, local: true, multipart: true) do
+  .govuk-form-group
+    label.govuk-label for='csv_file' Upload CSV file
+    input.govuk-file-upload id='csv_file' name='csv_file' type='file'
+
+  input.govuk-button type='submit' value='Upload'

--- a/app/views/admin/management/show.html.slim
+++ b/app/views/admin/management/show.html.slim
@@ -39,6 +39,10 @@ h1.govuk-heading-l Manage People Finder
     p.govuk-body
       | A stream of all changes on People Finder, along with the option to undo individual changes. You can also find a list of changes to a specific profile on the profile itself.
     = link_to 'Audit trail', audit_trail_path, class: 'govuk-button govuk-button--secondary'
+    h3.govuk-heading-s Import HR data
+    p.govuk-body
+      | Allows uploading of Oracle HR data fields into People Finder
+    = link_to 'Import HR data', new_admin_hr_data_import_path, class: 'govuk-button govuk-button--secondary'
 
   section#metrics.govuk-tabs__panel.govuk-tabs__panel--hidden
     h2.govuk-heading-m Metrics

--- a/app/views/people/edit.html.slim
+++ b/app/views/people/edit.html.slim
@@ -94,9 +94,26 @@
 
     .govuk-grid-row
       .govuk-grid-column-full
-        h2.govuk-heading-m Grade and manager
+        h2.govuk-heading-m My grade
 
-        = f.govuk_collection_select :grade, grade_names, :first, :last, options: {include_blank: true, prompt: false}
+        - if current_user.role_administrator?
+          = f.govuk_collection_select :grade, grade_names, :first, :last, options: {include_blank: true, prompt: false}
+        - else
+          p.govuk-body
+            - if person.grade.present?
+              = t(person.grade, scope: 'people.grade_names')
+            - else
+              | Grade not available
+          p.govuk-body-s
+            ' This information is updated from Oracle every month. If you are a civil servant and have recently joined
+            ' or changed grade, make sure this information is correct in Oracle and it will show on People Finder after
+            ' the next update. Contractors and staff from other departments will not have a grade shown here.
+
+        hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible
+
+    .govuk-grid-row
+      .govuk-grid-column-full
+        h2.govuk-heading-m My manager
 
         .govuk-form-group[class=('govuk-form-group--error' if @person.errors.include?(:line_manager))]
           label.govuk-label[for='person_line_manager']= self_or_other_label(person, :line_manager)

--- a/app/workers/update_person_from_hr_import_worker.rb
+++ b/app/workers/update_person_from_hr_import_worker.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class UpdatePersonFromHrImportWorker
+  include Sidekiq::Worker
+
+  def perform(hr_data_row) # rubocop:disable Metrics/MethodLength
+    record = HrDataRow.from_csv_row(hr_data_row)
+
+    if record.invalid?
+      error_msg = record.errors.full_messages.join(', ')
+      Rails.logger.error("[hr-data-import] Could not parse record (#{hr_data_row.join(',')}): #{error_msg}")
+      return
+    end
+
+    person = Person.find_by(email: record.email)
+
+    unless person
+      Rails.logger.warn("[hr-data-import] Could not match record '#{record.email}' to a People Finder user")
+      return
+    end
+
+    previous_grade = person.grade.to_s
+    if previous_grade == record.mapped_grade.to_s
+      Rails.logger.info("[hr-data-import] Grade for user '#{record.email}' has not changed")
+      return
+    end
+
+    PaperTrail.request(whodunnit: 'HR Data Import') do
+      person.update(grade: record.mapped_grade)
+    end
+
+    if previous_grade.present?
+      Rails.logger.info(
+        "[hr-data-import] Changed grade for user '#{record.email}' to #{record.mapped_grade} (was #{previous_grade})"
+      )
+    else
+      Rails.logger.info("[hr-data-import] Set grade for user '#{record.email}' to #{record.mapped_grade}")
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,6 +351,7 @@ en:
       non_graded_contractor: Non graded - contractor
       non_graded_secondee: Non graded - secondee
       non_graded_post: Non graded - post
+      intern: intern
     learning_and_development_names:
       shadowing: Work shadowing
       mentoring: Mentoring
@@ -447,6 +448,7 @@ en:
       audit_trail: Audit trail
       admin:
         management: Manage People Finder
+        hr_data_import: Import HR data
       groups:
         new: Add new sub-team
         edit: Edit team

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
 
     resource :profile_extract, only: [:show]
     resource :team_extract, only: [:show]
+    resource :hr_data_import, only: %i[new create show destroy]
 
     constraints AdminRouteConstraint.new do
       mount Sidekiq::Web => '/sidekiq'

--- a/spec/decorators/mailing_list_person_decorator_spec.rb
+++ b/spec/decorators/mailing_list_person_decorator_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 describe MailingListPersonDecorator do
   subject { described_class.new(person) }
 
-  let(:person) { build_stubbed(:person, email: email, country: 'AT', given_name: 'Mail', surname: 'Chimp', building: ['', 'skyscraper', 'airport']) }
+  let(:person) { build_stubbed(:person, email: email, country: 'AT', given_name: 'Mail', surname: 'Chimp', grade: 'intern', building: ['', 'skyscraper', 'airport']) }
   let(:email) { 'mail@chimp.com' }
 
   describe '#merge_fields' do
     it 'returns the expected Mailchimp merge fields' do
-      expect(subject.merge_fields).to eq({ FNAME: 'Mail', LNAME: 'Chimp', PF_COUNTRY: 'AT' })
+      expect(subject.merge_fields).to eq({ FNAME: 'Mail', LNAME: 'Chimp', PF_COUNTRY: 'AT', GRADE: 'intern' })
     end
   end
 

--- a/spec/models/hr_data_row_spec.rb
+++ b/spec/models/hr_data_row_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HrDataRow do
+  subject { described_class.new(email: email, grade: grade) }
+
+  let(:email) { 'gov@example.com' }
+  let(:grade) { 'SCS4 Level' }
+
+  describe '.from_csv_row' do
+    subject { described_class.from_csv_row(row) }
+
+    let(:row) { %w[4321234 Foo Bar Intern foo@example.com Domestic] }
+
+    it 'has the expected attributes' do
+      expect(subject.email).to eq('foo@example.com')
+      expect(subject.grade).to eq('Intern')
+    end
+  end
+
+  describe '#mapped_grade' do
+    it 'returns an appropriate grade mapping' do
+      expect(subject.mapped_grade).to eq(:scs_4)
+    end
+  end
+
+  describe 'validation' do
+    context 'email' do
+      context 'when missing' do
+        let(:email) { '' }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors).to include(:email)
+        end
+      end
+
+      context 'when incorrect' do
+        let(:email) { 'fsuidHSIEurhgloiehfjieo876' }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors).to include(:email)
+        end
+      end
+
+      context 'when unsanitized' do
+        let(:email) { '  Foo@EXAMPLE.com   ' }
+
+        it 'is sanitized and valid after validation' do
+          expect(subject).to be_valid
+          expect(subject.email).to eq('foo@example.com')
+        end
+      end
+    end
+
+    context 'grade' do
+      context 'when missing' do
+        let(:grade) { '' }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors).to include(:grade)
+        end
+      end
+
+      context 'when incorrect' do
+        let(:grade) { 'Grade 123' }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors).to include(:grade)
+        end
+      end
+
+      context 'when unspecified' do
+        let(:grade) { 'unspecified' }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'when containing Level' do
+        let(:grade) { 'EO Level' }
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/admin/management_policy_spec.rb
+++ b/spec/policies/admin/management_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-MANAGEMENT_ACTIONS = %i[show csv_extract_report sidekiq].freeze
+MANAGEMENT_ACTIONS = %i[show csv_extract_report sidekiq hr_data_imports].freeze
 
 RSpec.describe Admin::ManagementPolicy, type: :policy do
   subject { described_class.new(user, nil) }

--- a/spec/workers/update_person_from_hr_import_worker_spec.rb
+++ b/spec/workers/update_person_from_hr_import_worker_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UpdatePersonFromHrImportWorker do
+  let(:input) { %w[some hr data] }
+  let(:logger) { double('logger', info: true) }
+  let(:hr_data_row) { instance_double(HrDataRow, invalid?: false, email: 'foo@bar.com', mapped_grade: :scs_4) }
+
+  before do
+    allow(Rails).to receive(:logger).and_return(logger)
+    allow(HrDataRow).to receive(:from_csv_row).and_return(hr_data_row)
+  end
+
+  describe '#perform' do
+    context 'when the data is invalid' do
+      let(:errors) { double('errors', full_messages: %w[hello world]) }
+      let(:hr_data_row) { instance_double(HrDataRow, errors: errors, invalid?: true) }
+
+      it 'logs an error message' do
+        expect(logger).to receive(:error).with(a_string_matching(/Could not parse record.*hello, world/))
+
+        subject.perform(input)
+      end
+    end
+
+    context 'when no matching person is found' do
+      it 'logs a warning message' do
+        expect(logger).to receive(:warn).with(a_string_matching(/Could not match record/))
+
+        subject.perform(input)
+      end
+    end
+
+    context 'when a match is found but the grade has not changed' do
+      before do
+        create(:person, email: 'foo@bar.com', grade: :scs_4)
+      end
+
+      it 'logs an info message' do
+        expect(logger).to receive(:info).with(a_string_matching(/Grade for user 'foo@bar.com' has not changed/))
+
+        subject.perform(input)
+      end
+    end
+
+    context 'when a match is found and the grade has changed' do
+      let!(:person) { create(:person, email: 'foo@bar.com', grade: :scs_2) }
+
+      it 'logs an info message' do
+        expect(logger).to receive(:info).with(a_string_matching(/Changed grade for user 'foo@bar.com' to scs_4/))
+
+        subject.perform(input)
+      end
+
+      it 'updates the grade on the match' do
+        subject.perform(input)
+        person.reload
+
+        expect(person.grade).to eq('scs_4')
+      end
+
+      it 'adds a version with the correct whodunnit' do
+        with_versioning do
+          subject.perform(input)
+        end
+        person.reload
+
+        expect(person.versions.last.whodunnit).to eq('HR Data Import')
+      end
+    end
+  end
+end


### PR DESCRIPTION
For an urgent requirement, administrators need to be able to upload HR
data (specifically grades) to People Finder as a CSV file. This is the
simplest possible tactical solution to a complex integration problem
that needs to be solved properly in the long term.

- Add ability to upload CSVs of grades (with very strict format
  requirements) and background processing
- Remove ability for non-admin users to edit grade