### PR TITLE
fix: speculative fix on duplicate records on different pages in Data Workspace export

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -12,7 +12,7 @@ class Person < ApplicationRecord
 
   extend FriendlyId
 
-  default_scope { order(surname: :asc, given_name: :asc) }
+  default_scope { order(surname: :asc, given_name: :asc, id: :asc) }
 
   attr_accessor :working_days,
                 :crop_x, :crop_y, :crop_w, :crop_h,


### PR DESCRIPTION
Data Workspace experiences an intermittent issue where records are duplicated in the data it fetches from People Finder. The duplicate record is the last on one page, and the first in the next; and it looks like there are two users in People Finder with the this person's first and last names.

Before this PR, their order in the pagination is not defined, and so PostgreSQL is well with its rights to order them differently on each request. So, sometimes the same one of these two people will be on both pages.

So, we order people with the same name by their ID so it won't change between requests.