### PR TITLE
PFM-59 Remove "Windsor House" option from profile.

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,7 +5,7 @@ class Person < ApplicationRecord
     works_monday works_tuesday works_wednesday works_thursday works_friday works_saturday works_sunday
   ].freeze
   # rubocop:disable Naming/VariableNumber
-  BUILDING_OPTS = %i[whitehall_55 whitehall_3 victoria_50 horse_guards king_charles].freeze
+  BUILDING_OPTS = %i[whitehall_55 whitehall_3 horse_guards king_charles].freeze
   # rubocop:enable Naming/VariableNumber
 
   include Completion

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,7 +272,6 @@ en:
       home: Remote (home worker)
       whitehall_55: "55 Whitehall"
       whitehall_3: "3 Whitehall Place"
-      victoria_50: "Windsor House"
       horse_guards: "1 Horse Guards Rd"
       king_charles: "King Charles Street"
     key_skill_names:


### PR DESCRIPTION
Deployment steps:
1. deploy code
2. run the following SQL

```sql
UPDATE
    people
SET
    building =
    CASE
        WHEN array_position(building, 'home') IS NULL
        THEN array_replace(building, 'victoria_50', 'home')
        ELSE array_remove(building, 'victoria_50')
    END
WHERE
    array_position(building, 'victoria_50') IS NOT NULL;
```

This query will move all users from "Windsor House" to "Remote (home worker)".